### PR TITLE
README: Fix typography description

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ www/
 - **Background**: Dark theme with glass morphism effects
 
 ### Typography
-- **Primary Font**: 'Montserrat' (Headings)
-- **Secondary Font**: 'Zen Kaku Gothic New' (Body text)
+- **Alphanumeric**: [Montserrat](https://fonts.google.com/specimen/Montserrat)
+- **Japanese**: [Zen Kaku Gothic New](https://fonts.google.com/specimen/Zen+Kaku+Gothic+New)
 
 ### Components
 The site uses custom shortcodes for reusable components:


### PR DESCRIPTION
We use Montserrat for Latin and numeric glyphs, and Zen Kaku Gothic
New for Japanese glyphs. This distinction is based on language, not on
primary versus secondary fonts.