### PR TITLE
Issue #6: Correct "Recruit" page prefooter text (Products, About Us, and Contact)

### DIFF
--- a/content/about_us/_index.en.md
+++ b/content/about_us/_index.en.md
@@ -85,8 +85,8 @@ Now, we deploy our space computers in CubeSats using Space One's KAIROS rocket. 
 
   left_title = "PRODUCTS"
   left_subtitle = "Board introduction"
-  left_footer_1 = "We provide reliable products and"
-  left_footer_2 = "support space development."
+  left_footer_1 = "Even in extreme environments,"
+  left_footer_2 = "these computers function normally."
   left_link = "/en/products"
 
   right_title="RECRUIT",

--- a/content/about_us/_index.md
+++ b/content/about_us/_index.md
@@ -87,8 +87,8 @@ TEL｜050-7112-6213
 
   left_title = "PRODUCTS"
   left_subtitle = "製品紹介"
-  left_footer_1 = "信頼性の高い製品を提供し、"
-  left_footer_2 = "宇宙開発をサポートします。"
+  left_footer_1 = "極限の環境でも"
+  left_footer_2 = "正常に動作するコンピューターを"
   left_link = "/products"
 
   right_title="RECRUIT",

--- a/content/recruit/_index.en.md
+++ b/content/recruit/_index.en.md
@@ -68,27 +68,27 @@ Thermal Engineer |
 {% end %}
 
 {% prefooter(
-  left_card_image="sq_about_img2.jpg", 
-  right_card_image="earth.jpg",
+  left_card_image="white_pcb_dark.jpg", 
+  right_card_image="sq_about_img2.jpg",
 
-  left_title="ABOUT US",
-  left_subtitle="Company details",
-  left_footer_1="We are always looking for new members to join our team.",
-  left_footer_2="If you are interested, please contact us.",
-  left_link="/about_us",
+  left_title="PRODUCTS",
+  left_subtitle="Board introduction",
+  left_footer_1="Even in extreme environments,",
+  left_footer_2="these computers function normally.",
+  left_link="/en/products",
 
-  right_title="CONTACT",
-  right_subtitle="Send us a message",
-  right_footer_1="Please feel free to contact us.",
-  right_footer_2="A representative will respond to you.",
-  right_link="/contact",
+  right_title="ABOUT US",
+  right_subtitle="Company details",
+  right_footer_1="Aiming for an era where anyone can go to the moon,",
+  right_footer_2="we are a JAXA venture developing affordable and reliable computers for space use.",
+  right_link="/en/about_us",
 
   bottom_card_image = "<!--display element -->",
-  bottom_title="PRODUCTS",
-  bottom_subtitle="Board introduction",
-  bottom_footer_1="We provide reliable products and",
-  bottom_footer_2="support space development.",
-  bottom_link="/products",
+  bottom_title="CONTACT",
+  bottom_subtitle="Reach out to us.",
+  bottom_footer_1="We welcome inquiries about our business and services.",
+  bottom_footer_2="Please feel free to contact us.",
+  bottom_link="/en/contact",
 
   bg=""
 ) %}

--- a/content/recruit/_index.md
+++ b/content/recruit/_index.md
@@ -66,27 +66,27 @@ FPGAエンジニア |
 {% end %}
 
 {% prefooter(
-  left_card_image="sq_about_img2.jpg", 
-  right_card_image="earth.jpg",
+  left_card_image="white_pcb_dark.jpg", 
+  right_card_image="sq_about_img2.jpg",
 
-  left_title="ABOUT US",
-  left_subtitle="私たちについて",
-  left_footer_1="一緒に働くメンバーを常に募集しています。",
-  left_footer_2="ご興味のある方はご連絡ください。",
-  left_link="/about_us",
+  left_title="PRODUCTS",
+  left_subtitle="製品紹介",
+  left_footer_1="極限の環境でも",
+  left_footer_2="正常に動作するコンピューターを",
+  left_link="/products",
 
-  right_title="CONTACT",
-  right_subtitle="お問い合わせ",
-  right_footer_1="お気軽にお問い合わせください。",
-  right_footer_2="担当者よりご返信いたします",
-  right_link="/contact",
+  right_title="ABOUT US",
+  right_subtitle="私たちについて",
+  right_footer_1="「誰もが月に行ける時代」を目指し、",
+  right_footer_2="安価で信頼性の高い宇宙用コンピュータを開発するJAXAベンチャーです。",
+  right_link="/about_us",
 
   bottom_card_image = "<!--display element -->",
-  bottom_title="PRODUCTS",
-  bottom_subtitle="製品紹介",
-  bottom_footer_1="信頼性の高い製品を提供し、",
-  bottom_footer_2="宇宙開発をサポートします。",
-  bottom_link="/products",
+  bottom_title="CONTACT",
+  bottom_subtitle="お問い合わせ",
+  bottom_footer_1="事業やサービスについてご相談・ご質問承ります。",
+  bottom_footer_2="お気軽にお問い合わせください。",
+  bottom_link="/contact",
 
   bg=""
 ) %}


### PR DESCRIPTION
fix(prefooter text): ensure last recruit page prefooter card is consistent with designer's specified design.

The last prefooter card on the "Recruit" page was inconsistent with other pages, where "contact" is always the last box. This change aligns with the designer's specifications. Additionally, prefooter text for About Us and Products was also corrected in line with designer specifications (English and Japanese).

BEFORE:
<img width="1202" height="686" alt="image" src="https://github.com/user-attachments/assets/129fe7fe-911e-43d5-909f-3c20c0aa15c5" />

AFTER:
<img width="1202" height="686" alt="image" src="https://github.com/user-attachments/assets/4ef08a1f-0bc6-46d9-9836-b2121153e58e" />

# Issue
This fixes #6
