### PR TITLE
captcha: use get_env method

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -31,8 +31,6 @@ show_backlinks = true
 contact_url = "contact"
 source_url = "https://github.com/spacecubics/www"
 
-captcha_site_key = ""
-
 [extra.nav]
 show_feed = true
 show_repo = true

--- a/templates/shortcodes/application_form.html
+++ b/templates/shortcodes/application_form.html
@@ -74,7 +74,7 @@
 			<div class="z-contact-form__turnstile-wrapper">
 				<div
 					class="cf-turnstile"
-					data-sitekey="{{ config.extra.captcha_site_key }}"
+					data-sitekey="{{ get_env(name="CAPTCHA_SITE_KEY")  }}"
 					data-callback="onTurnstileSuccess"
 					data-theme="light"
 				></div>

--- a/templates/shortcodes/contact_form.html
+++ b/templates/shortcodes/contact_form.html
@@ -48,7 +48,7 @@
 		<p class="z-contact-form__field">
 			<div
 				class="cf-turnstile"
-				data-sitekey="{{ config.extra.captcha_site_key }}"
+				data-sitekey="{{ get_env(name="CAPTCHA_SITE_KEY") }}"
 				data-callback="onTurnstileSuccess"
 				data-theme="light"
 			></div>


### PR DESCRIPTION
# Goal
- Remove config.extra.captcha_site_key from config.toml
- Use get_env built-in Tera engine function in HTML
# Other
- Make matching change in README.md
- Coordinate with @takumiando to use `zola build` rather than `build.sh` on Cloudflare.
# Issue
This closes #16 
