### PR TITLE
shortcodes: Default CAPTCHA_SITE_KEY to empty string

### DIFF
--- a/templates/shortcodes/application_form.html
+++ b/templates/shortcodes/application_form.html
@@ -74,7 +74,7 @@
 			<div class="z-contact-form__turnstile-wrapper">
 				<div
 					class="cf-turnstile"
-					data-sitekey="{{ get_env(name="CAPTCHA_SITE_KEY")  }}"
+					data-sitekey="{{ get_env(name="CAPTCHA_SITE_KEY", default="")  }}"
 					data-callback="onTurnstileSuccess"
 					data-theme="light"
 				></div>

--- a/templates/shortcodes/contact_form.html
+++ b/templates/shortcodes/contact_form.html
@@ -48,7 +48,7 @@
 		<p class="z-contact-form__field">
 			<div
 				class="cf-turnstile"
-				data-sitekey="{{ get_env(name="CAPTCHA_SITE_KEY") }}"
+				data-sitekey="{{ get_env(name="CAPTCHA_SITE_KEY", default="") }}"
 				data-callback="onTurnstileSuccess"
 				data-theme="light"
 			></div>


### PR DESCRIPTION
Without a default, `get_env("CAPTCHA_SITE_KEY")` would error when the variable isn’t set:

    ❯ ~/src/zola/target/debug/zola serve
    Building site...
    Error: Failed to serve the site
    Error: Failed to render content of ..../content/contact/_index.en.md
    Error: Reason: Failed to render contact_form shortcode
    Error: Reason: Failed to render 'shortcodes/contact_form.html'
    Error: Reason: Function call 'get_env' failed
    Error: Reason: Environment variable `CAPTCHA_SITE_KEY` not found

This change supplies an empty-string default, preventing build failures when the CAPTCHA key isn’t provided.