### PR TITLE
fix: documentation URLs

### DIFF
--- a/content/products/_index.en.md
+++ b/content/products/_index.en.md
@@ -35,11 +35,13 @@
 	text3_a="Operating System",
 	text3_b="Zephyr RTOS",
 	download_1_link="https://github.com/spacecubics/scobc-a1-product-manual",
-	download_1_label="User Manual",
+	download_1_label="Space Cubics Documentation",
 	download_2_link="https://docs.zephyrproject.org/latest/boards/sc/scobc_a1/doc/index.html",
-	download_2_label="Zephyr Docs",
+	download_2_label="Zephyr Project Documentation",
 	download_3_link="https://github.com/spacecubics",
-	download_3_label="GitHub",
+	download_3_label="Space Cubics GitHub",
+	download_4_link="https://github.com/zephyrproject-rtos/zephyr",
+	download_4_label="Zephyr RTOS GitHub Repository",
 	details_link="/en/sc_obc"
 ) %}
 <!-- no text -->

--- a/content/products/_index.md
+++ b/content/products/_index.md
@@ -35,11 +35,13 @@
 	text3_a="Operating System",
 	text3_b="Zephyr RTOS",
 	download_1_link="https://github.com/spacecubics/scobc-a1-product-manual",
-	download_1_label="User Manual",
+	download_1_label="Space Cubics Documentation",
 	download_2_link="https://docs.zephyrproject.org/latest/boards/sc/scobc_a1/doc/index.html",
-	download_2_label="Zephyr Docs",
+	download_2_label="Zephyr Project Documentation",
 	download_3_link="https://github.com/spacecubics",
-	download_3_label="GitHub",
+	download_3_label="Space Cubics GitHub",
+	download_4_link="https://github.com/zephyrproject-rtos/zephyr",
+	download_4_label="Zephyr RTOS GitHub Repository",
 	details_link="/sc_obc"
 ) %}
 <!-- no text -->

--- a/templates/shortcodes/product_display.html
+++ b/templates/shortcodes/product_display.html
@@ -41,38 +41,22 @@
 		</div>
 
 		<div class="product-downloads">
-			<span class="download-pair">
-				<span class="download-label">{{ download_1_label }}</span>
-				<a href="{{ download_1_link }}" class="download-link" aria-label="{{ download_1_label }}">
-					<svg class="download-icon" width="16" height="16" viewBox="0 0 24 24" fill="none"
-						xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-						<path class="cls-1"
-							d="M3.45,19.4c-1.9,0-3.45-1.55-3.45-3.45v-2.5c0-.52.43-.95.95-.95s.95.43.95.95v2.5c0,.85.7,1.55,1.55,1.55h10c.85,0,1.55-.7,1.55-1.55v-2.5c0-.52.43-.95.95-.95s.95.43.95.95v2.5c0,1.9-1.55,3.45-3.45,3.45H3.45ZM8.45,13.15c-.25,0-.49-.1-.67-.28L2.78,7.87c-.37-.37-.37-.97,0-1.35.18-.18.42-.28.67-.28s.49.1.67.28l2.87,2.87c.06.06.13.09.21.09.04,0,.08,0,.11-.02.11-.05.19-.16.19-.28V.95c0-.52.43-.95.95-.95s.95.43.95.95v8.23c0,.12.07.23.19.28.04.02.08.02.11.02.08,0,.15-.03.21-.09l2.87-2.87c.18-.18.42-.28.67-.28s.49.1.67.28c.37.37.37.97,0,1.35,0,0-4.99,4.99-5,5-.18.18-.42.28-.67.28Z" />
-					</svg>
-				</a>
-			</span>
-
-			<span class="download-pair">
-				<span class="download-label">{{ download_2_label }}</span>
-				<a href="{{ download_2_link }}" class="download-link" aria-label="{{ download_2_label }}">
-					<svg class="download-icon" width="16" height="16" viewBox="0 0 24 24" fill="none"
-						xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-						<path class="cls-1"
-							d="M3.45,19.4c-1.9,0-3.45-1.55-3.45-3.45v-2.5c0-.52.43-.95.95-.95s.95.43.95.95v2.5c0,.85.7,1.55,1.55,1.55h10c.85,0,1.55-.7,1.55-1.55v-2.5c0-.52.43-.95.95-.95s.95.43.95.95v2.5c0,1.9-1.55,3.45-3.45,3.45H3.45ZM8.45,13.15c-.25,0-.49-.1-.67-.28L2.78,7.87c-.37-.37-.37-.97,0-1.35.18-.18.42-.28.67-.28s.49.1.67.28l2.87,2.87c.06.06.13.09.21.09.04,0,.08,0,.11-.02.11-.05.19-.16.19-.28V.95c0-.52.43-.95.95-.95s.95.43.95.95v8.23c0,.12.07.23.19.28.04.02.08.02.11.02.08,0,.15-.03.21-.09l2.87-2.87c.18-.18.42-.28.67-.28s.49.1.67.28c.37.37.37.97,0,1.35,0,0-4.99,4.99-5,5-.18.18-.42.28-.67.28Z" />
-					</svg>
-				</a>
-			</span>
-
-			<span class="download-pair">
-				<span class="download-label">{{ download_3_label }}</span>
-				<a href="{{ download_3_link }}" class="download-link" aria-label="{{ download_3_label }}">
-					<svg class="download-icon" width="16" height="16" viewBox="0 0 24 24" fill="none"
-						xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
-						<path class="cls-1"
-							d="M3.45,19.4c-1.9,0-3.45-1.55-3.45-3.45v-2.5c0-.52.43-.95.95-.95s.95.43.95.95v2.5c0,.85.7,1.55,1.55,1.55h10c.85,0,1.55-.7,1.55-1.55v-2.5c0-.52.43-.95.95-.95s.95.43.95.95v2.5c0,1.9-1.55,3.45-3.45,3.45H3.45ZM8.45,13.15c-.25,0-.49-.1-.67-.28L2.78,7.87c-.37-.37-.37-.97,0-1.35.18-.18.42-.28.67-.28s.49.1.67.28l2.87,2.87c.06.06.13.09.21.09.04,0,.08,0,.11-.02.11-.05.19-.16.19-.28V.95c0-.52.43-.95.95-.95s.95.43.95.95v8.23c0,.12.07.23.19.28.04.02.08.02.11.02.08,0,.15-.03.21-.09l2.87-2.87c.18-.18.42-.28.67-.28s.49.1.67.28c.37.37.37.97,0,1.35,0,0-4.99,4.99-5,5-.18.18-.42.28-.67.28Z" />
-					</svg>
-				</a>
-			</span>
+			{% set download_labels = [download_1_label, download_2_label, download_3_label, download_4_label] %}
+			{% set download_links = [download_1_link, download_2_link, download_3_link, download_4_link] %}
+			{% for i in range(start=0, end=download_labels | length) %}
+				{% if download_labels[i] and download_links[i] %}
+					<span class="download-pair">
+						<span class="download-label">{{ download_labels[i] }}</span>
+						<a href="{{ download_links[i] }}" class="download-link" aria-label="{{ download_labels[i] }}">
+							<svg class="download-icon" width="16" height="16" viewBox="0 0 24 24" fill="none"
+								xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+								<path class="cls-1"
+									d="M3.45,19.4c-1.9,0-3.45-1.55-3.45-3.45v-2.5c0-.52.43-.95.95-.95s.95.43.95.95v2.5c0,.85.7,1.55,1.55,1.55h10c.85,0,1.55-.7,1.55-1.55v-2.5c0-.52.43-.95.95-.95s.95.43.95.95v2.5c0,1.9-1.55,3.45-3.45,3.45H3.45ZM8.45,13.15c-.25,0-.49-.1-.67-.28L2.78,7.87c-.37-.37-.37-.97,0-1.35.18-.18.42-.28.67-.28s.49.1.67.28l2.87,2.87c.06.06.13.09.21.09.04,0,.08,0,.11-.02.11-.05.19-.16.19-.28V.95c0-.52.43-.95.95-.95s.95.43.95.95v8.23c0,.12.07.23.19.28.04.02.08.02.11.02.08,0,.15-.03.21-.09l2.87-2.87c.18-.18.42-.28.67-.28s.49.1.67.28c.37.37.37.97,0,1.35,0,0-4.99,4.99-5,5-.18.18-.42.28-.67.28Z" />
+							</svg>
+						</a>
+					</span>
+				{% endif %}
+			{% endfor %}
 		</div>
 
 		{% if details_link %}


### PR DESCRIPTION
# Changes
- add "Zephyr RTOS GitHub Repository" + link
- change "User Manual" to "Space Cubics Documentation"
- change "Zephyr Docs" to "Zephyr Project Documentation"
- change "GitHub" to "Space Cubics GitHub"
- make product_display documentation block DRY

# Issues
This fixes #54 