### PR TITLE
templates: shortcodes: Simplify board_members

### DIFF
--- a/content/about_us/_index.en.md
+++ b/content/about_us/_index.en.md
@@ -27,18 +27,7 @@ Address｜Venture Square 301, 1, South-3 East-2, Chuo-ku, Sapporo, Japan 060-005
 TEL｜+81-50-7112-6213
 {% end %}
 
-{% board_members (
-	title="BOARD MEMBERS",
-	subtitle="Executive",
-	slogan="PROFILES"
-) %}
-Yasushi Shoji (荘司 靖)｜CEO｜Software Engineer｜Graduating from Salem State University, MA, USA in 2000, Mr. Shoji has been engaged in embedded CPU board development since 2002. Leveraging extensive knowledge and experience, he previously led software development for a space drone (Int-Ball) project in 2016.
-Daisuke Sasaki (佐々木 大輔)｜CTO｜LSI Logic Engineer｜Since 2001, Mr. Sasaki has gained extensive experience in various LSI design processes over his 11 years of experience in the semiconductor industry. Since 2013, he has worked to develop embedded CPU boards equipped with LSIs. Mr. Sasaki is also a skilled software developer.
-Fumito Morishima (森島 史仁)｜CFO｜Sales, Finance Control｜For 16 years, Mr. Morishima was involved in the development, sales, marketing, and management of embedded CPU boards. He also started a business in Southeast Asia and possesses a broad network of industry connections.
-Takuya Sasaki (佐々木 拓也)｜CAO｜Software Engineer, Sales｜Starting in 1998, Mr. Sasaki has been working as a software engineer for a Japanese electronics manufacturer, mainly developing network management systems for government agencies. In 2013, he worked as a field application engineer (FAE) for an embedded CPU board manufacturer, supporting both development and mass production.
-Tomohiro Namitsuka (波塚 朋広)｜CPO｜Electronics Engineer｜Starting in 2002, Mr. Namitsuka worked as a hardware engineer for an embedded CPU board manufacturer where he was responsible for the development of numerous circuit boards. Leveraging extensive knowledge and experience in circuit designs that require special environmental resistance, he now works to provide affordable and reliable spacecraft computers.
-Masayuki Goto (後藤 雅享)｜Founding Member｜Space System Engineer｜ Mr. Goto worked on manned space development at JAXA. He has been responsible for numerous development projects for the International Space Station, and has extensive experience in how computers function during launch and space operation. More broadly, Mr. Goto's aim is to advance space development in both the public and private sectors.
-{% end %}
+{{ board_members(members="blocks/board-members.json", lang="en") }}
 
 {% hero_element(
 	title="PARTNERS",

--- a/content/about_us/_index.md
+++ b/content/about_us/_index.md
@@ -27,18 +27,7 @@
 TEL｜050-7112-6213
 {% end %}
 
-{% board_members (
-	title="BOARD MEMBERS",
-	subtitle="Executive",
-	slogan="PROFILES"
-) %}
-荘司 靖 (Yasushi Shoji)｜CEO｜Software Engineer｜2000年にSalem State Univ., MA, USA 卒業。2002年より組み込みCPUボード開発に従事。幅広い知識と経験を生かし、2016年に宇宙用ドローン(Int-Ball)の統括ソフトウェア開発を担当。
-佐々木 大輔 (Daisuke Sasaki)｜CTO｜LSI Logic Engineer｜2001年より11年間 国内半導体企業にてLSIの開発における幅広い設計工程を経験。2013年から自ら設計したLSIを搭載した組み込みCPUボードの開発を経験しソフトウェアまで知識領域を持つ。
-森島 史仁 (Fumito Morishima)｜CFO｜Sales, Finance Control｜2000年より16年間、組み込みCPUボードメーカーにて開発・営業・マーケティング・経営に携わり、幅広いビジネススキルを習得。また東南アジアで事業を興しており、アジアにコネクションを持つ。
-佐々木 拓也 (Takuya Sasaki)｜CAO｜Software Engineer, Sales｜1998年より国内電機メーカーのソフトウェアエンジニアとして主に官公庁向けのネットワーク管理システムの開発に従事。2013年から組み込みCPUボードメーカーのFAEとして、数多くの顧客の開発、量産をサポートしてきた。
-波塚 朋広 (Tomohiro Namitsuka)｜CPO｜Electronics Engineer｜2002年より組み込みCPUボードメーカーのハードウェアエンジニアとして、多くの基板開発を担当。耐環境性・信頼性が要求される産業用途向け製品の回路設計から量産製造までの幅広い知識と経験を活かし、安価で安心して使える宇宙機の提供を目指す。
-後藤 雅享 (Masayuki Goto)｜Founding Member｜Space System Engineer｜2002年よりJAXAにて有人宇宙開発に従事。国際宇宙ステーションに搭載する数々の機器開発プロジェクトを担当し、広い分野での開発・打上げ・運用経験を持つ。JAXAと民間の両面から宇宙開発の発展を目指す。
-{% end %}
+{{ board_members(members="blocks/board-members.json", lang="ja") }}
 
 {% hero_element(
 	title="PARTNERS",

--- a/sass/_board_members.scss
+++ b/sass/_board_members.scss
@@ -108,7 +108,7 @@
 		margin-bottom: 0.2em;
 	}
 
-	&__name {
+	&__name-main {
 		font-family: 'Montserrat', 'Zen Kaku Gothic New', sans-serif;
 		font-size: 1.5em;
 		color: white;
@@ -116,7 +116,7 @@
 		line-height: 1.1;
 	}
 
-	&__en-name {
+	&__name-sub {
 		font-family: 'Montserrat', 'Zen Kaku Gothic New', sans-serif;
 		font-size: 1em;
 		color: #bbbbbb;

--- a/static/blocks/board-members.json
+++ b/static/blocks/board-members.json
@@ -1,0 +1,50 @@
+[
+		{
+				"name_ja": "荘司 靖",
+				"name_en": "Yasushi Shoji",
+				"title": "CEO",
+				"expertise": "Software Engineer",
+				"bio_ja": "2000年にSalem State Univ., MA, USA 卒業。2002年より組み込みCPUボード開発に従事。幅広い知識と経験を生かし、2016年に宇宙用ドローン(Int-Ball)の統括ソフトウェア開発を担当。",
+				"bio_en": "Graduating from Salem State University, MA, USA in 2000, Mr. Shoji has been engaged in embedded CPU board development since 2002. Leveraging extensive knowledge and experience, he previously led software development for a space drone (Int-Ball) project in 2016."
+		},
+		{
+				"name_ja": "佐々木 大輔",
+				"name_en": "Daisuke Sasaki",
+				"title": "CTO",
+				"expertise": "LSI Logic Engineer",
+				"bio_ja": "2001年より11年間 国内半導体企業にてLSIの開発における幅広い設計工程を経験。2013年から自ら設計したLSIを搭載した組み込みCPUボードの開発を経験しソフトウェアまで知識領域を持つ。",
+				"bio_en": "Since 2001, Mr. Sasaki has gained extensive experience in various LSI design processes over his 11 years of experience in the semiconductor industry. Since 2013, he has worked to develop embedded CPU boards equipped with LSIs. Mr. Sasaki is also a skilled software developer."
+		},
+		{
+				"name_ja": "森島 史仁",
+				"name_en": "Fumito Morishima",
+				"title": "CFO",
+				"expertise": "Sales, Finance Control",
+				"bio_ja": "2000年より16年間、組み込みCPUボードメーカーにて開発・営業・マーケティング・経営に携わり、幅広いビジネススキルを習得。また東南アジアで事業を興しており、アジアにコネクションを持つ。",
+				"bio_en": "For 16 years, Mr. Morishima was involved in the development, sales, marketing, and management of embedded CPU boards. He also started a business in Southeast Asia and possesses a broad network of industry connections."
+		},
+		{
+				"name_ja": "佐々木 拓也",
+				"name_en": "Takuya Sasaki",
+				"title": "CAO",
+				"expertise": "Software Engineer, Sales",
+				"bio_ja": "1998年より国内電機メーカーのソフトウェアエンジニアとして主に官公庁向けのネットワーク管理システムの開発に従事。2013年から組み込みCPUボードメーカーのFAEとして、数多くの顧客の開発、量産をサポートしてきた。",
+				"bio_en": "Starting in 1998, Mr. Sasaki has been working as a software engineer for a Japanese electronics manufacturer, mainly developing network management systems for government agencies. In 2013, he worked as a field application engineer (FAE) for an embedded CPU board manufacturer, supporting both development and mass production."
+		},
+		{
+				"name_ja": "波塚 朋広",
+				"name_en": "Tomohiro Namitsuka",
+				"title": "CPO",
+				"expertise": "Electronics Engineer",
+				"bio_ja": "2002年より組み込みCPUボードメーカーのハードウェアエンジニアとして、多くの基板開発を担当。耐環境性・信頼性が要求される産業用途向け製品の回路設計から量産製造までの幅広い知識と経験を活かし、安価で安心して使える宇宙機の提供を目指す。",
+				"bio_en": "Starting in 2002, Mr. Namitsuka worked as a hardware engineer for an embedded CPU board manufacturer where he was responsible for the development of numerous circuit boards. Leveraging extensive knowledge and experience in circuit designs that require special environmental resistance, he now works to provide affordable and reliable spacecraft computers."
+		},
+		{
+				"name_ja": "後藤 雅享",
+				"name_en": "Masayuki Goto",
+				"title": "Founding Member",
+				"expertise": "Space System Engineer",
+				"bio_ja": "2002年よりJAXAにて有人宇宙開発に従事。国際宇宙ステーションに搭載する数々の機器開発プロジェクトを担当し、広い分野での開発・打上げ・運用経験を持つ。JAXAと民間の両面から宇宙開発の発展を目指す。",
+				"bio_en": "Mr. Goto worked on manned space development at JAXA. He has been responsible for numerous development projects for the International Space Station, and has extensive experience in how computers function during launch and space operation. More broadly, Mr. Goto's aim is to advance space development in both the public and private sectors."
+		}
+]

--- a/templates/shortcodes/board_members.html
+++ b/templates/shortcodes/board_members.html
@@ -1,86 +1,35 @@
+{% set members = load_data(path=members, format="json") %}
+{% set count = members | length %}
+
 <div class="board-members">
 	<div class="board-members-left">
-		{% if title %}
-			<h2 class="board-members__title">{{ title }}</h2>
-		{% endif %}
-		{% if subtitle %}
-			<p class="board-members__subtitle">{{ subtitle }}</p>
-		{% endif %}
-		{% if slogan %}
-			<p class="board-members__slogan">{{ slogan }}</p>
-		{% endif %}
+		<h2 class="board-members__title">BOARD MEMBERS</h2>
+		<p class="board-members__subtitle">Executive</p>
+		<p class="board-members__slogan">PROFILES</p>
 		<div class="board-members__divider"></div>
 	</div>
 
 	<div class="board-members-right">
 		<div class="board-members-grid">
-			{% set lines = body | split(pat="\n") %}
-			{% for line in lines %}
-				{% set parts = line | split(pat="｜") %}
-
-				{% if parts | length > 0 %}
-					{% set name = parts[0] | trim %}
-				{% else %}
-					{% set name = "" %}
-				{% endif %}
-
-				{% if parts | length > 1 %}
-					{% set title = parts[1] | trim %}
-				{% else %}
-					{% set title = "" %}
-				{% endif %}
-
-				{% if parts | length > 2 %}
-					{% set position = parts[2] | trim %}
-				{% else %}
-					{% set position = "" %}
-				{% endif %}
-
-				{% if parts | length > 3 %}
-					{% set bio = parts[3] | trim %}
-				{% else %}
-					{% set bio = "" %}
-				{% endif %}
-
-				{% if parts | length > 4 %}
-					{% set img = parts[4] | trim %}
-				{% else %}
-					{% set img = "" %}
-				{% endif %}
-
-				<div class="board-card">
-					{% if img != "" %}
-						<img src="{{ img }}" alt="{{ name }}" class="board-card__image" />
-					{% endif %}
-
-					{% if position != "" %}
-						<div class="board-card__role">{{ position }}</div>
-					{% endif %}
-
-					{% set name_parts = name | split(pat="(") %}
-					{% set jp_name = name_parts[0] | trim %}
-					{% if name_parts | length > 1 %}
-						{% set en_name = name_parts[1] | replace(from=")", to="") | trim %}
+			{% for member in members %}
+			<div class="board-card">
+				<div class="board-card__role">{{ member.expertise }}</div>
+				<div class="board-card__name-row">
+					{% if lang == "ja" %}
+					<span class="board-card__name-main">{{ member.name_ja }}</span>
+					<span class="board-card__name-sub">{{ member.name_en }}</span>
 					{% else %}
-						{% set en_name = "" %}
-					{% endif %}
-
-					<div class="board-card__name-row">
-						<span class="board-card__name">{{ jp_name }}</span>
-						{% if en_name != "" %}
-							<span class="board-card__en-name">{{ en_name }}</span>
-						{% endif %}
-					</div>
-
-					{% if title != "" %}
-						{# Removed: no need to display CEO, CTO, etc. #}
-					{% endif %}
-
-					{% if bio != "" %}
-						<div class="board-card__bio">{{ bio }}</div>
+					<span class="board-card__name-main">{{ member.name_en }}</span>
+					<span class="board-card__name-sub">{{ member.name_ja }}</span>
 					{% endif %}
 				</div>
+				{% if lang == "ja" %}
+				<div class="board-card__bio">{{ member.bio_ja }}</div>
+				{% else %}
+				<div class="board-card__bio">{{ member.bio_en }}</div>
+				{% endif %}
+			</div>
 			{% endfor %}
-		</div>
-	</div>
+	  </div>
+  </div>
 </div>


### PR DESCRIPTION
Move data to static/blocks/board-members.json to load structured data at render time. This reduces the size of the board_member shortcode by half without losing functionality.