### PR TITLE
config.toml: Disable slugify

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -18,6 +18,9 @@ bottom_footnotes = true
 title = "Space Cubics, Inc."
 description = "English site"
 
+[slugify]
+paths = "off"
+
 [extra]
 default_theme = "dark"
 accent_color = "#ff7800"


### PR DESCRIPTION
Zola's default behavior is to slugify the file names. It's confusing at best. In fact, the links to the about_us page were broken.

We don't really care about SEO. So, disable it.