### PR TITLE
templates: shortcodes: tagline: Specify tagline class

### DIFF
--- a/templates/shortcodes/tagline.html
+++ b/templates/shortcodes/tagline.html
@@ -1,4 +1,4 @@
-<div>
+<div class="tagline">
 	<h1 class="tagline-title">{{ title }}</h1>
 	<div class="tagline-subtitle">{{ statement | safe }}</div>
 </div>


### PR DESCRIPTION
We have some style setup in the "tagline" class. Without it, child styles has different values. See #92 for more details.

We should have a plan how we organize our font sizes (#110), but for now, we use what we have.