### PR TITLE
News article template is not done

### DIFF
--- a/sass/_news_article.scss
+++ b/sass/_news_article.scss
@@ -1,42 +1,27 @@
 // News Article Styles
-.news-article {
-	max-width: 700px;
-	margin: 3rem auto 4rem auto;
-	background: #181a1b;
-	border-radius: 18px;
-	box-shadow: 0 4px 32px rgba(0,0,0,0.18);
-	padding: 2.5rem 2rem 2rem 2rem;
-	color: #f3f3f3;
-	font-family: 'Zen Kaku Gothic New', 'Helvetica Neue', Arial, sans-serif;
+.news-article {	
+	background: transparent;
+	margin-top: 6em;
+	margin-left: auto;
+	margin-right: auto;
+	max-width: 75%;
 
-	.news-article-title {
-		font-size: 2.2rem;
-		font-weight: 700;
-		margin-bottom: 1.2rem;
-		letter-spacing: 0.04em;
-		color: #fff;
-		text-shadow: 0 2px 8px rgba(0,0,0,0.12);
-		text-align: center;
+	.news-article-date {
+		text-align: left;
+		margin-bottom: 5em;
 	}
 
-	.news-article-img {
-		display: block;
-		max-width: 100%;
-		max-height: 340px;
-		margin: 0 auto 2rem auto;
-		border-radius: 12px;
-		box-shadow: 0 2px 16px rgba(0,0,0,0.18);
-		object-fit: cover;
+	.news-article-title {
+		font-size: 2em;
+		font-weight: 700;
+		text-align: left;
+		margin-bottom: 2em;
 	}
 
 	.news-article-content {
-		font-size: 1.15rem;
-		line-height: 1.8;
-		margin-bottom: 2.2rem;
-		color: #e0e0e0;
-		word-break: break-word;
+		font-size: 1em;
 		a {
-			color: #4ec9f3;
+			color: #ffffff;
 			text-decoration: underline;
 			transition: color 0.2s;
 			&:hover {
@@ -44,64 +29,27 @@
 			}
 		}
 		p {
-			margin: 1.2em 0;
-		}
-		ul, ol {
-			margin: 1.2em 0 1.2em 2em;
+			margin-bottom: 4em;
 		}
 	}
 
-	.news-article-link {
-		margin-top: 2.5rem;
-		text-align: center;
-		a {
-			display: inline-block;
-			background: linear-gradient(90deg, #ff9800 0%, #ff7f00 100%);
-			color: #181a1b;
+	.news-article-back {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: 2em;
+		margin-top: 4em;
+
+		.back-text {
+			color: #ff7800;
+			font-size: 1.2em;
 			font-weight: 600;
-			padding: 0.85em 2.2em;
-			border-radius: 8px;
-			font-size: 1.1rem;
-			text-decoration: none;
-			box-shadow: 0 2px 12px rgba(255,152,0,0.10);
-			position: relative;
-			overflow: hidden;
-			transition: background 0.2s, color 0.2s, box-shadow 0.2s;
-			/* Animated underline */
-			&::after {
-				content: '';
-				display: block;
-				position: absolute;
-				left: 50%;
-				bottom: 0.3em;
-				width: 0;
-				height: 3px;
-				background: linear-gradient(90deg, #ff7f00 0%, #ff9800 100%);
-				border-radius: 2px;
-				transition: width 0.3s cubic-bezier(0.4,0,0.2,1), left 0.3s cubic-bezier(0.4,0,0.2,1);
-			}
-			&:hover {
-				background: linear-gradient(90deg, #ff7f00 0%, #ff9800 100%);
-				color: #fff;
-				box-shadow: 0 4px 24px rgba(255,152,0,0.18);
-				&::after {
-					width: 80%;
-					left: 10%;
-				}
-			}
-			/* Optional: add a link icon */
+		}
+
+		.back-btn {
 			&::before {
-				content: '\1F517'; /* Unicode link symbol */
-				margin-right: 0.5em;
-				font-size: 1.1em;
-				vertical-align: middle;
-				opacity: 0.7;
-				color: #ff9800;
-				transition: opacity 0.2s, color 0.2s;
-			}
-			&:hover::before {
-				opacity: 1;
-				color: #fff;
+				transform: translate(-60%, -50%);
+				clip-path: path('M16 0 L0 6 L16 12 L12 6 Z');
 			}
 		}
 	}
@@ -109,52 +57,40 @@
 
 @media (max-width: 800px) {
 	.news-article {
-		padding: 1.5rem 0.5rem 1.5rem 0.5rem;
-		.news-article-title {
-			font-size: 1.5rem;
-		}
-		.news-article-img {
-			max-height: 200px;
-		}
-	}
-}
-
-@media (max-width: 600px) {
-	.news-article {
-		padding: 0.7rem 0.2rem 1rem 0.2rem;
-		.news-article-title {
-			font-size: 1.1rem;
-		}
-		.news-article-img {
-			max-height: 120px;
-			border-radius: 8px;
-		}
-		.news-article-content {
-			font-size: 1rem;
-		}
-		.news-article-link a {
-			font-size: 0.98rem;
-			padding: 0.7em 1.2em;
+		.news-article-back {
+			.back-btn {
+				&::before {
+					width: 14px;
+					height: 10px;
+					clip-path: path('M14 0 L0 5 L14 10 L10 5 Z');
+				}
+			}
 		}
 	}
 }
 
-@media (max-width: 400px) {
+@media (max-width: 500px) {
 	.news-article {
-		padding: 0.3rem 0.1rem 0.7rem 0.1rem;
+		.news-article-date {
+			font-size: 0.8rem;
+		}
 		.news-article-title {
 			font-size: 0.95rem;
-		}
-		.news-article-img {
-			max-height: 80px;
-			border-radius: 6px;
 		}
 		.news-article-content {
 			font-size: 0.92rem;
 		}
-		.news-article-link a {
-			font-size: 0.9rem;
-			padding: 0.5em 0.7em;
+		.news-article-back {
+			.back-btn {
+				width: 40px;
+				height: 40px;
+				font-size: 16px;
+				&::before {
+					width: 12px;
+					height: 9px;
+					clip-path: path('M12 0 L0 4.5 L12 9 L9 4.5 Z');
+				}
+			}
 		}
 	}
 }

--- a/templates/news_article.html
+++ b/templates/news_article.html
@@ -1,42 +1,45 @@
-{% extends "base.html" %}
+{% extends "section.html" %}
 
 {% block content %}
+	{% set bg = "" %}
+	{% set title = "NEWS" %}
+	{% set subtitle = "お知らせ" %}
+	{% set slogan = "" %}
+	{% set style_top = "お知らせ/" ~ page.title %}
+	{% include "partials/section_title.html" %}
+
 	<article class="news-article">
-		<header>
-			<h1 class="news-article-title">
-				{# Use the date from the path as in the list #}
-				{% set path_parts = page.path | split(pat="/") %}
-				{% set last_index = path_parts | length - 2 %}
-				{% set date_candidate = path_parts[last_index] %}
-				{% set date_str = date_candidate | replace(from=".en", to="") | replace(from=".md", to="") %}
-				{{ date_str }}
-			</h1>
-			{% if page.extra.image %}
-				<img src="/{{ page.extra.image }}" alt="{{ page.title }}" class="news-article-img">
-			{% else %}
-				<img src="/logo_solid.png" alt="{{ page.title }}" class="news-article-img">
-			{% endif %}
-		</header>
+		<div class="news-article-date">
+			{{ page.date }}
+		</div>
+		<div class="news-article-title">
+			{{ page.title }}
+		</div>
 		<div class="news-article-content">
 			{{ page.content | safe }}
 		</div>
 		{% if page.extra.link %}
-			<div class="news-article-link">
-				<a href="{{ page.extra.link }}" target="_blank" rel="noopener">
-					{{ page.extra.link }}
-				</a>
-			</div>
+			<a href="{{ page.extra.link }}" target="_blank" rel="noopener" class="news-article-link">
+				{{ page.extra.link }}
+			</a>
 		{% endif %}
+		<div class="news-article-back">
+			<span class="back-text">Back to List</span>
+			<a href="{{ get_url(path='news/', lang=lang) }}" class="circle-btn back-btn">
+			</a>
+		</div>
 	</article>
 
-{%- if page.extra.prefooter_cards -%}
-<div class="section">
-	<div class="card-grid single-bottom-card">
-		{% set page_name = "contact/_index.en.md" %}
-		{% set bottom_card = True %}
-		{% include "partials/prefooter_card.html" %}
+	<div class="section">
+		<div class="card-grid single-bottom-card">
+			{% if lang == "en" %}
+				{% set page_name = "contact/_index.en.md" %}
+			{% else %}
+				{% set page_name = "contact/_index.md" %}
+			{% endif %}
+			{% set bottom_card = True %}
+			{% include "partials/prefooter_card.html" %}
+		</div>
 	</div>
-</div>
-{%- endif -%}
 
 {% endblock content %}


### PR DESCRIPTION
## Task
Re-design news article template

## Changes
Revise news_article.html and .scss
- Add section title
- Implement basic centered layout
- Add "Back to List" text and button
- Auto-include contact prefooter card

## Visual Changes
BEFORE:
<img width="702" height="695" alt="image" src="https://github.com/user-attachments/assets/7bb12413-0f35-4ff4-bd2d-7562f41dedd8" />

AFTER:
<img width="702" height="695" alt="image" src="https://github.com/user-attachments/assets/3c94ac28-0c0b-4aad-a1d1-e9777a56bb2f" />

## Issues
This fixes #107 

## Other

`page.content | safe`  is used in news_article.html line 19 because of text corruption.

With `| safe `:
<img width="846" height="79" alt="image" src="https://github.com/user-attachments/assets/4d3039b6-991c-4677-9280-2359d0038abf" />

Without `| safe` :
<img width="814" height="121" alt="image" src="https://github.com/user-attachments/assets/81e4a670-4567-41fd-951e-2f5fd5c5300c" />
