### PR TITLE
content: news: Remove empty extra from the front matter

### DIFF
--- a/content/news/_index.en.md
+++ b/content/news/_index.en.md
@@ -5,6 +5,4 @@ template = "news_section.html"
 page_template = "news_article.html"
 paginate_by = 10
 sort_by = "date"
-
-[extra]
 +++

--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -5,6 +5,4 @@ template = "news_section.html"
 page_template = "news_article.html"
 paginate_by = 10
 sort_by = "date"
-
-[extra]
 +++


### PR DESCRIPTION
Remove the empty `[extra]` table from the front matter of the index.