### PR TITLE
Fix: use config.toml inline SVG icons in splash footer

### DIFF
--- a/sass/_splash.scss
+++ b/sass/_splash.scss
@@ -36,7 +36,7 @@
 	}
 
 .splash-footer {
-	position: relative; /* for absolute positioning context */
+	position: relative;
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: right;
@@ -108,10 +108,19 @@
 	height: 1.8rem;
 	color: white;
 	transition: opacity 0.3s ease;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .social-icons a:hover {
 	opacity: 0.3;
+}
+
+.social-icons .icon {
+	mask-image: var(--icon);
+	width: 100%;
+	height: 100%;
 }
 
 @keyframes floatDown {
@@ -143,9 +152,17 @@
 		display: none;
 	}
 
+	.splash-footer {
+		justify-content: center;
+		margin-left: 20px;
+		margin-right: 20px;
+		gap: 1rem;
+		margin-bottom: 20px;
+	}
+
 	.social-icons a {
-		width: 1.5rem;
-		height: 1.5rem;
+		width: 1.5em;
+		height: 1.5em;
 	}
 }
 
@@ -161,6 +178,11 @@
 	.social-icons a {
 		width: 5.4rem;
 		height: 5.4rem;
+	}
+
+	.social-icons .icon {
+		width: 100%;
+		height: 100%;
 	}
 	.social-label {
 		font-size: 3rem;

--- a/templates/shortcodes/splash.html
+++ b/templates/shortcodes/splash.html
@@ -9,39 +9,15 @@
 	<div class="splash-footer">
 		<div class="social-icons">
 			<span class="social-label">SOCIAL</span>
-			<a href="https://www.youtube.com/channel/UCcTXF6z-D5B2xkDamlPzSzg" target="_blank" rel="noopener">
-				<svg role="img" viewBox="0 2 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
-					<title>YouTube</title>
-					<path d="M23.498 6.186a2.958 2.958 0 0 0-2.08-2.088C19.845 3.5 12 3.5 12 3.5s-7.845 0-9.418.598a2.958 2.958 0 0 0-2.08 2.088A30.061 30.061 0 0 0 0 12a30.06 30.06 0 0 0 .502 5.814 2.958 2.958 0 0 0 2.08 2.088C4.155 20.5 12 20.5 12 20.5s7.845 0 9.418-.598a2.958 2.958 0 0 0 2.08-2.088A30.06 30.06 0 0 0 24 12a30.06 30.06 0 0 0-.502-5.814zM9.75 15.5v-7l6.5 3.5-6.5 3.5z"/>
-				</svg>
-			</a>
-			<a href="https://www.linkedin.com/company/spacecubics" target="_blank" rel="noopener">
-				<svg role="img" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-					<title>LinkedIn</title>
-					<path d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854zm4.943 12.248V6.169H2.542v7.225zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.52-1.248-1.342-1.248S2.4 3.226 2.4 3.934c0 .694.521 1.248 1.327 1.248zm4.908 8.212V9.359c0-.216.016-.432.08-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016l.016-.025V6.169h-2.4c.03.678 0 7.225 0 7.225z"/>
-				</svg>
-			</a>
-			<a href="https://x.com/SpaceCubics" target="_blank" rel="noopener">
-				<svg role="img" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-					<title>X</title>
-					<path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"/>
-				</svg>
-			</a>
-			<a href="https://www.facebook.com/spacecubics/" target="_blank" rel="noopener">
-				<svg role="img" viewBox="0 0 28 28" xmlns="http://www.w3.org/2000/svg">
-					<title>Facebook</title>
-					<path fill="currentColor" d="M22.675 0H1.325C.593 0 0 .593 0 1.326V22.67c0 .732.593 1.325 1.326 1.325h11.49v-9.837H9.692v-3.838h3.124V7.41c0-3.1 1.894-4.788 4.66-4.788 1.325 0 2.464.099 2.796.143v3.24h-1.918c-1.504 0-1.796.715-1.796 1.763v2.312h3.59l-.467 3.838h-3.123V24h6.116c.73 0 1.324-.593 1.324-1.326V1.326C24 .593 23.406 0 22.675 0z"/>
-				</svg>
-			</a>
-			<a href="https://github.com/spacecubics/" target="_blank" rel="noopener">
-				<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-					<title>GitHub</title>
-					<path fill="currentColor" d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.387.6.113.82-.258.82-.577v-2.234c-3.338.724-4.033-1.415-4.033-1.415-.546-1.387-1.333-1.757-1.333-1.757-1.089-.745.084-.729.084-.729 1.205.084 1.84 1.236 1.84 1.236 1.07 1.835 2.807 1.305 3.495.998.107-.776.418-1.305.762-1.605-2.665-.3-5.467-1.335-5.467-5.93 0-1.31.468-2.38 1.235-3.22-.124-.303-.535-1.523.117-3.176 0 0 1.008-.322 3.3 1.23a11.5 11.5 0 0 1 3-.404c1.02.005 2.047.138 3 .404 2.29-1.552 3.296-1.23 3.296-1.23.653 1.653.242 2.873.118 3.176.77.84 1.235 1.91 1.235 3.22 0 4.61-2.807 5.625-5.48 5.92.43.372.823 1.104.823 2.227v3.303c0 .319.218.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/>
-				</svg>
-			</a>
+			{%- if config.extra.footer.socials %}
+				{%- for link in config.extra.footer.socials %}
+					<a href="{{ link.url }}" target="_blank" rel="noopener" title="{{ link.name }}">
+						<i class="icon" style='--icon: url("data:image/svg+xml,{{ link.icon }}")'></i>
+					</a>
+				{%- endfor %}
+			{%- endif %}
 		</div>
 	</div>
-
 
 	<div class="banner-image">
 		<img src="/slide_typeface.png" />


### PR DESCRIPTION
## Changes
Replace duplicate splash.html SVGs with those from config.toml for simplicity.

Add styling for these changes and better
mobile screen centering.

## Issues
This fixes #125 

## Visual changes 
<img width="417" height="80" alt="image" src="https://github.com/user-attachments/assets/c19143b8-34f0-4399-9760-fe6426ca7d6e" />
