### PR TITLE
recruit: fix broken job link

### DIFF
--- a/content/recruit/_index.en.md
+++ b/content/recruit/_index.en.md
@@ -27,7 +27,7 @@ Space Cubics is young and still growing. If you are interested in the astrocompu
 	slogan = "POSITIONS",
 	jobs_note = "Special notes: For positions other than those currently being recruited, please inquire via the inquiry form.",
 	jobs = "
-Software Engineer | software-engineer/ | active
+Software Engineer | software_engineer | active
 Communications Engineer |
 Fundraising Manager |
 FPGA Engineer |

--- a/content/recruit/_index.md
+++ b/content/recruit/_index.md
@@ -27,7 +27,7 @@ card_body = """一緒に働くメンバーを常に募集しています。
 	slogan = "POSITIONS",
 	jobs_note = "特記事項：募集中以外の職種に関しては、お問合せフォームよりお問合せ願います。",
 	jobs = "
-ソフトウェアエンジニア | software-engineer/ | active
+ソフトウェアエンジニア | software_engineer | active
 通信エンジニア |
 資金調達担当 |
 FPGAエンジニア |


### PR DESCRIPTION
## Changes

Change job path from software-engineer (hyphenated) to software_engineer (underscore) to recover link.
Also remove final forward slash (not needed for link). 

Likely cause: [slugify] paths = "off".

[Screencast from 2025-08-04 13-18-35.webm](https://github.com/user-attachments/assets/24e6602d-6b29-4b5f-b7b1-10bca7e68512)

# Issues
This fixes #137 
