### PR TITLE
templates: Set date_locale and date_format globally

### DIFF
--- a/templates/article.html
+++ b/templates/article.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 
 {% block content %}
-	{%- set date_locale = macros_translate::translate(key="date_locale", default="en_US", language_strings=language_strings) -%}
 	{%- set rel_attributes = macros_rel_attributes::rel_attributes() | trim -%}
 
 	<article>

--- a/templates/article_list.html
+++ b/templates/article_list.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% block content %}
-	{%- set date_locale = macros_translate::translate(key="date_locale", default="en_US", language_strings=language_strings) -%}
 	<h1>{{ section.title }}</h1>
 	{{ section.content | safe }}
 	{% include "partials/articles.html" %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,8 @@
 {% import "macros/rel_attributes.html" as macros_rel_attributes %}
 {% import "macros/translate.html" as macros_translate %}
 {%- set language_strings = load_data(path="i18n/" ~ lang ~ ".toml", required=false) -%}
+{%- set date_locale = macros_translate::translate(key="date_locale", default="en_US", language_strings=language_strings) -%}
+{%- set date_format = macros_translate::translate(key="date_format", language_strings=language_strings) -%}
 
 
 <!DOCTYPE html>

--- a/templates/job_post.html
+++ b/templates/job_post.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 
 {% block content %}
-{%- set date_format = macros_translate::translate(key="date_format", language_strings=language_strings) -%}
-
 <article class="job-post">
 	<header class="job-post__header">
 		<h1 class="job-post__title">{{ page.title }}</h1>

--- a/templates/news_article.html
+++ b/templates/news_article.html
@@ -1,7 +1,6 @@
 {% extends "section.html" %}
 
 {% block content %}
-	{%- set date_format = macros_translate::translate(key="date_format", language_strings=language_strings) -%}
 	{% set bg = "" %}
 	{% set title = "NEWS" %}
 	{% set subtitle = "お知らせ" %}

--- a/templates/partials/news_list_block.html
+++ b/templates/partials/news_list_block.html
@@ -1,5 +1,3 @@
-{%- set date_format = macros_translate::translate(key="date_format", language_strings=language_strings) -%}
-
 <div class="news-list-block">
 	{% for news in all_news %}
 	<div class="news-list-line">

--- a/templates/recruit_list.html
+++ b/templates/recruit_list.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 
 {% block content %}
-{%- set date_locale = macros_translate::translate(key="date_locale", default="en_US", language_strings=language_strings) -%}
 
 {%- if paginator.pages -%}
 	{%- set number_of_posts = paginator.total_pages -%}


### PR DESCRIPTION
Set `date_locale` and `date_format` in base.html to make them available throughout all pages.