### PR TITLE
Fix: inconsistent gap between news list dates and titles

### DIFF
--- a/sass/_sc-list.scss
+++ b/sass/_sc-list.scss
@@ -1,0 +1,48 @@
+.sc-list {
+	&__item {
+		display: grid;
+		grid-template-columns: 140px 1fr;
+		align-items: center;
+		margin-bottom: 1em;
+	}
+
+	&__label {
+		font-weight: 700;
+		color: white;
+		white-space: nowrap;
+		font-size: 0.9em;
+	}
+
+	&__value {
+		margin-left: 55px;
+	}
+
+	&__link {
+		color: inherit;
+		text-decoration: none;
+		transition: color 0.3s ease;
+		display: block;
+		line-height: 1.4;
+
+		&:hover {
+			color: #ff7800;
+		}
+	}
+
+	&__divider {
+		height: 2px;
+		width: 100%;
+		background: linear-gradient(to right, #ff7800 80px, #666 1px);
+		margin-top: 1em;
+		margin-bottom: 1em;
+	}
+
+	@media (max-width: 479px) {
+		&__item {
+			grid-template-columns: 90px 1fr;
+			gap: 5px;
+			align-items: center;
+			font-size: 0.8em;
+		}
+	}
+}

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -25,7 +25,6 @@
 @use "language_switcher";
 @use "nav";
 @use "news_article";
-
 @use "news_section";
 @use "notfound";
 @use "post-nav";
@@ -33,6 +32,7 @@
 @use "product_display";
 @use "quick_jump";
 @use "recruit_intro";
+@use "sc-list";
 @use "scroll_hint";
 @use "sparkline";
 @use "spec_sheet";

--- a/templates/partials/news_list_block.html
+++ b/templates/partials/news_list_block.html
@@ -1,17 +1,13 @@
-<div class="news-list-block">
-	{% for news in all_news %}
-	<div class="news-list-line">
-		<p>
-			<span class="news-date">
-				<time datetime>{{ news.date | date(format=date_format) }}</time>
-			</span>
-			<span class="news-gap">
-				<a href="{{ news.permalink }}" class="news-title-link">
-					{{ news.title }}
-				</a>
-			</span>
-		</p>
-		<div class="news-divider-bar"></div>
-	</div>
-	{% endfor %}
+{% for news in all_news %}
+<div class="sc-list__item">
+	<span class="sc-list__label">
+		<time datetime>{{ news.date | date(format=date_format) }}</time>
+	</span>
+	<span class="sc-list__value">
+		<a href="{{ news.permalink }}" class="sc-list__link">
+			{{ news.title }}
+		</a>
+	</span>
 </div>
+<div class="sc-list__divider"></div>
+{% endfor %}


### PR DESCRIPTION
## Changes
- Create reusable style file `_sc-list.scss` following BEM methodology.

- Revise `news_list_block.html` to use `sc-list` styling.

## Issues

This fixes #119 

## Other

`_sc-list.scss` can be used in other parts of the site with lists.

### Example : `kv-list.html`

<img width="656" height="368" alt="Screenshot from 2025-08-06 11-14-24" src="https://github.com/user-attachments/assets/115be5cd-f5d3-4559-b810-811b4155f5ee" />

<img width="1263" height="228" alt="Screenshot from 2025-08-06 11-14-14" src="https://github.com/user-attachments/assets/d00ad3ec-2eb6-4da9-95b8-118f16353dac" />

