### PR TITLE
fix: geometric font anomaly

### DIFF
--- a/sass/_prefooter.scss
+++ b/sass/_prefooter.scss
@@ -92,8 +92,8 @@
 		margin-bottom: 0.8rem;
 		margin-top: 0;
 		line-height: 1.1;
+		font-family: "Arial";
 		letter-spacing: 0.1em;
-		-webkit-text-stroke: 3px rgb(255, 255, 255);
 
 		@media (max-width: 1024px) {
 			font-size: 2.6rem !important;


### PR DESCRIPTION
## Changes
- Fix font anomaly on prefooter card-header by replacing webkit-text-stroke with common system font Arial.


Geometric fonts can cause these anomalies when enlarged using webkit-text-stroke.

## Issues
This fixes #147 