### PR TITLE
Load Google font weights and remove use of -webkit in scss

### DIFF
--- a/sass/_about_company.scss
+++ b/sass/_about_company.scss
@@ -47,8 +47,6 @@
 	font-weight: 900;
 	text-align: left;
 	margin: 0;
-	-webkit-text-stroke: 2px white;
-	text-stroke: 2px white;
 	letter-spacing: 0.1em;
 	text-shadow:
 		0 0 0 white,

--- a/sass/_alerts.scss
+++ b/sass/_alerts.scss
@@ -8,7 +8,6 @@ blockquote {
 		}
 
 		.alert-title .icon {
-			-webkit-mask-image: var(--icon-info);
 			mask-image: var(--icon-info);
 		}
 	}
@@ -22,7 +21,6 @@ blockquote {
 		}
 
 		.alert-title .icon {
-			-webkit-mask-image: var(--icon-lightbulb);
 			mask-image: var(--icon-lightbulb);
 		}
 	}
@@ -36,7 +34,6 @@ blockquote {
 		}
 
 		.alert-title .icon {
-			-webkit-mask-image: var(--icon-important);
 			mask-image: var(--icon-important);
 		}
 	}
@@ -50,7 +47,6 @@ blockquote {
 		}
 
 		.alert-title .icon {
-			-webkit-mask-image: var(--icon-warning);
 			mask-image: var(--icon-warning);
 		}
 	}
@@ -64,7 +60,6 @@ blockquote {
 		}
 
 		.alert-title .icon {
-			-webkit-mask-image: var(--icon-caution);
 			mask-image: var(--icon-caution);
 		}
 	}

--- a/sass/_article-list.scss
+++ b/sass/_article-list.scss
@@ -65,7 +65,6 @@
 			font-family: var(--font-system-ui);
 
 			&::after {
-				-webkit-mask-image: var(--icon-right);
 				display: inline-block;
 				position: relative;
 				transform: translateX(-0.25rem);
@@ -133,7 +132,6 @@
 			--bg-overlay: var(--fg-muted-1);
 
 			&::before {
-				-webkit-mask-image: var(--icon-pencil);
 				mask-image: var(--icon-pencil);
 				background-color: var(--fg-muted-1);
 			}
@@ -147,7 +145,6 @@
 				color: var(--fg-muted-5);
 
 				.icon {
-					-webkit-mask-image: var(--icon-pencil);
 					mask-image: var(--icon-pencil);
 				}
 			}
@@ -167,7 +164,6 @@
 			--bg-overlay: var(--purple-bg);
 
 			&::before {
-				-webkit-mask-image: var(--icon-archive);
 				mask-image: var(--icon-archive);
 				background-color: var(--purple-bg);
 			}
@@ -181,7 +177,6 @@
 				color: var(--purple-fg);
 
 				.icon {
-					-webkit-mask-image: var(--icon-archive);
 					mask-image: var(--icon-archive);
 				}
 			}
@@ -201,7 +196,6 @@
 			--bg-overlay: var(--yellow-bg);
 
 			&::before {
-				-webkit-mask-image: var(--icon-star);
 				mask-image: var(--icon-star);
 				background-color: var(--yellow-bg);
 			}
@@ -225,7 +219,6 @@
 				color: var(--yellow-fg);
 
 				.icon {
-					-webkit-mask-image: var(--icon-star);
 					mask-image: var(--icon-star);
 				}
 			}
@@ -245,7 +238,6 @@
 			--bg-overlay: var(--red-bg);
 
 			&::before {
-				-webkit-mask-image: var(--icon-fire);
 				mask-image: var(--icon-fire);
 				background-color: var(--red-bg);
 			}
@@ -259,7 +251,6 @@
 				color: var(--red-fg);
 
 				.icon {
-					-webkit-mask-image: var(--icon-fire);
 					mask-image: var(--icon-fire);
 				}
 			}
@@ -279,7 +270,6 @@
 			--bg-overlay: var(--brown-bg);
 
 			&::before {
-				-webkit-mask-image: var(--icon-poop);
 				mask-image: var(--icon-poop);
 				background-color: var(--brown-bg);
 			}
@@ -293,7 +283,6 @@
 				color: var(--brown-fg);
 
 				.icon {
-					-webkit-mask-image: var(--icon-poop);
 					mask-image: var(--icon-poop);
 				}
 			}
@@ -401,22 +390,18 @@
 	}
 
 	#paginator-first .icon {
-		-webkit-mask-image: var(--icon-first);
 		mask-image: var(--icon-first);
 	}
 
 	#paginator-previous .icon {
-		-webkit-mask-image: var(--icon-previous);
 		mask-image: var(--icon-previous);
 	}
 
 	#paginator-next .icon {
-		-webkit-mask-image: var(--icon-next);
 		mask-image: var(--icon-next);
 	}
 
 	#paginator-last .icon {
-		-webkit-mask-image: var(--icon-last);
 		mask-image: var(--icon-last);
 	}
 

--- a/sass/_article.scss
+++ b/sass/_article.scss
@@ -1,6 +1,5 @@
 #banner-container {
 	--mask: linear-gradient(black, transparent);
-	-webkit-user-select: none;
 	position: absolute;
 	z-index: -1;
 	mask-image: var(--mask);
@@ -34,7 +33,6 @@
 	text-align: center;
 
 	h1 {
-		-webkit-background-clip: text;
 		margin: 0;
 		background-image: linear-gradient(
 			to right,

--- a/sass/_article.scss
+++ b/sass/_article.scss
@@ -1,7 +1,6 @@
 #banner-container {
 	--mask: linear-gradient(black, transparent);
 	-webkit-user-select: none;
-	-webkit-mask-image: var(--mask);
 	position: absolute;
 	z-index: -1;
 	mask-image: var(--mask);

--- a/sass/_board_members.scss
+++ b/sass/_board_members.scss
@@ -22,8 +22,6 @@
 		margin: 0 0 0.2em;
 		color: white;
 		letter-spacing: 1px;
-		-webkit-text-stroke: 1px white;
-		text-stroke: 1px white;
 	}
 
 	&__subtitle {

--- a/sass/_code.scss
+++ b/sass/_code.scss
@@ -49,7 +49,6 @@ pre {
 	}
 
 	table td:nth-of-type(1) {
-		-webkit-user-select: none;
 		user-select: none;
 		text-align: center;
 	}

--- a/sass/_external.scss
+++ b/sass/_external.scss
@@ -1,5 +1,4 @@
 a.external::after {
-	-webkit-mask-image: var(--icon-external);
 	display: inline-block;
 	opacity: var(--dim-opacity);
 	mask-image: var(--icon-external);

--- a/sass/_feed.scss
+++ b/sass/_feed.scss
@@ -3,7 +3,6 @@ h1 a:has(.icon.feed) {
 }
 
 h1 .icon.feed {
-	-webkit-mask-image: var(--icon-feed);
 	vertical-align: -0.375rem;
 	mask-image: var(--icon-feed);
 	margin-inline-start: 0.5rem;

--- a/sass/_footer.scss
+++ b/sass/_footer.scss
@@ -228,7 +228,6 @@
 			}
 
 			.icon {
-				-webkit-mask-image: var(--icon);
 				mask-image: var(--icon);
 				transition: var(--transition);
 				width: 2.5rem;

--- a/sass/_hero_element.scss
+++ b/sass/_hero_element.scss
@@ -61,7 +61,6 @@
 				margin-bottom: 0.2em;
 				font-family: 'Montserrat', 'Zen Kaku Gothic New', sans-serif;
 				letter-spacing: 0.1em;
-				-webkit-text-stroke: 3px rgb(255, 255, 255);
 				white-space: nowrap;
 			}
 

--- a/sass/_iframe.scss
+++ b/sass/_iframe.scss
@@ -22,9 +22,4 @@ iframe {
 		box-shadow: none;
 		border-radius: 0;
 	}
-
-	&:-webkit-full-screen {
-		box-shadow: none;
-		border-radius: 0;
-	}
 }

--- a/sass/_input.scss
+++ b/sass/_input.scss
@@ -69,7 +69,6 @@ input[type="checkbox"] {
 	border-radius: calc(var(--rounded-corner-small) / 2);
 
 	&::before {
-		-webkit-mask-image: var(--icon-checkmark);
 		transform-origin: bottom left;
 		mask-image: var(--icon-checkmark);
 		mask-size: cover;

--- a/sass/_input.scss
+++ b/sass/_input.scss
@@ -146,14 +146,6 @@ input[type="color"] {
 		border: none;
 		border-radius: calc(var(--rounded-corner-small) - 0.25rem);
 	}
-
-	&::-webkit-color-swatch-wrapper {
-		padding: 0;
-	}
-
-	&::-webkit-color-swatch {
-		border-radius: calc(var(--rounded-corner-small) - 0.25rem);
-	}
 }
 
 input[type="range"] {
@@ -165,23 +157,6 @@ input[type="range"] {
 	background: var(--accent-color);
 	width: 100%;
 	height: 0.5rem;
-
-	&::-webkit-slider-thumb {
-		appearance: none;
-		filter: brightness(0.9);
-		transition: var(--transition);
-		cursor: grab;
-		box-shadow: var(--shadow);
-		border-radius: 999px;
-		background-color: white;
-		width: 1.5rem;
-		height: 1.5rem;
-
-		&:active {
-			transform: var(--active);
-			cursor: grabbing;
-		}
-	}
 
 	&::-moz-range-thumb {
 		appearance: none;

--- a/sass/_nav.scss
+++ b/sass/_nav.scss
@@ -265,7 +265,6 @@
 				border-radius: calc(var(--rounded-corner) + 0.25rem);
 				background-color: var(--glass-bg);
 				backdrop-filter: var(--blur);
-				-webkit-backdrop-filter: var(--blur);
 				box-shadow: none;
 
 				.dropdown-item {

--- a/sass/_normalize.scss
+++ b/sass/_normalize.scss
@@ -7,7 +7,6 @@
 //
 
 :where(html) {
-	-webkit-text-size-adjust: 100%; // 2
 	text-size-adjust: 100%; // 2
 	line-height: 1.15; // 1
 }
@@ -120,17 +119,6 @@
 }
 
 //
-// Correct the inability to style buttons in iOS and Safari.
-//
-
-:where(
-		button,
-		input:is([type="button" i], [type="reset" i], [type="submit" i])
-	) {
-	-webkit-appearance: button;
-}
-
-//
 // Add the correct vertical alignment in Chrome, Edge, and Firefox.
 //
 
@@ -160,44 +148,7 @@
 //
 
 :where(input[type="search" i]) {
-	-webkit-appearance: textfield; // 1
 	outline-offset: -2px; // 2
-}
-
-//
-// Correct the cursor style of increment and decrement buttons in Safari.
-//
-
-::-webkit-inner-spin-button,
-::-webkit-outer-spin-button {
-	height: auto;
-}
-
-//
-// Correct the text style of placeholders in Chrome, Edge, and Safari.
-//
-
-::-webkit-input-placeholder {
-	opacity: 0.54;
-	color: inherit;
-}
-
-//
-// Remove the inner padding in Chrome, Edge, and Safari on macOS.
-//
-
-::-webkit-search-decoration {
-	-webkit-appearance: none;
-}
-
-//
-// 1. Correct the inability to style upload buttons in iOS and Safari.
-// 2. Change font properties to `inherit` in Safari.
-//
-
-::-webkit-file-upload-button {
-	-webkit-appearance: button; // 1
-	font: inherit; // 2
 }
 
 //

--- a/sass/_prefooter.scss
+++ b/sass/_prefooter.scss
@@ -93,7 +93,6 @@
 		margin-top: 0;
 		line-height: 1.1;
 		letter-spacing: 0.1em;
-		-webkit-text-stroke: 3px rgb(255, 255, 255);
 
 		@media (max-width: 1024px) {
 			font-size: 2.6rem !important;

--- a/sass/_tagline.scss
+++ b/sass/_tagline.scss
@@ -8,7 +8,6 @@
 		letter-spacing: 0.05em;
 		margin-bottom: 0.5rem;
 		padding: 1rem 1rem;
-		-webkit-text-stroke: 1px rgb(255, 255, 255);
 	}
 
 	&-subtitle {
@@ -26,7 +25,6 @@
 			font-weight: 950;
 			letter-spacing: 0.05em;
 			text-align: center;
-			-webkit-text-stroke: 1px rgb(255, 255, 255);
 		}
 
 		&-subtitle {

--- a/sass/_threecard.scss
+++ b/sass/_threecard.scss
@@ -10,8 +10,6 @@
 		font-weight: 950;
 		letter-spacing: 0.05em;
 		margin-bottom: 0.5rem;
-		-webkit-text-stroke: 1px rgb(255, 255, 255);
-		text-stroke: 1px rgb(255, 255, 255);
 	}
 
 	&-subtitle {
@@ -150,8 +148,6 @@
 			font-weight: 950;
 			letter-spacing: 0.05em;
 			text-align: center;
-			-webkit-text-stroke: 1px rgb(255, 255, 255);
-			text-stroke: 1px rgb(255, 255, 255);
 		}
 
 		&-subtitle {

--- a/sass/_title.scss
+++ b/sass/_title.scss
@@ -22,7 +22,6 @@
 	font-size: 3rem !important;
 	font-weight: 950 !important;
 	letter-spacing: 0.1em;
-	-webkit-text-stroke: 3px rgb(255, 255, 255);
 }
 
 .title-content h3 {

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -235,7 +235,6 @@ details summary::-webkit-details-marker {
 
 details summary::before {
 	mask-image: var(--icon-down);
-	-webkit-mask-image: var(--icon-down);
 	display: inline-block;
 	vertical-align: -0.125em;
 	transition: var(--transition);

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -126,16 +126,7 @@ progress:indeterminate::-moz-progress-bar {
 	background-color: transparent;
 }
 
-progress::-webkit-progress-bar {
-	background-color: transparent;
-}
-
 progress::-moz-progress-bar {
-	border-radius: 999px;
-	background-color: var(--accent-color);
-}
-
-progress::-webkit-progress-value {
 	border-radius: 999px;
 	background-color: var(--accent-color);
 }
@@ -228,8 +219,7 @@ details summary {
 	list-style: none;
 }
 
-details summary::marker,
-details summary::-webkit-details-marker {
+details summary::marker {
 	display: none;
 }
 

--- a/sass/_zola-anchor.scss
+++ b/sass/_zola-anchor.scss
@@ -44,7 +44,6 @@ h6 {
 	}
 
 	.icon {
-		-webkit-mask-image: var(--icon-link);
 		mask-image: var(--icon-link);
 		mask-size: cover;
 		transition: var(--transition);

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -14,5 +14,5 @@
 	<link type="text/css" rel="stylesheet" href="{{ get_url(path='style.css') | safe }}" />
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=Montserrat&family=Zen+Kaku+Gothic+New&display=swap" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300..700&family=Zen+Kaku+Gothic+New:wght@300..700&display=swap" rel="stylesheet">
 </head>


### PR DESCRIPTION
## Changes

- Load a range of font weights via Google CSS API for global access. This fixes geometric anomalies seen in rendered large text.

- Remove `-webkit-*` from scss files.

## Issues

This fixes #147 

This fixes #149 
