### PR TITLE
fix: remove text anomaly due to font weight conflicts

### DIFF
--- a/content/recruit/software_engineer/index.en.md
+++ b/content/recruit/software_engineer/index.en.md
@@ -5,8 +5,8 @@ date = 2025-07-18
 template = "job_post.html"
 +++
 # Now Hiring
-## **Software Engineer**
-## **Location:**
+## Software Engineer
+## Location:
 Head Office (Remote work within Japan only)
 ---
 ### Employment Type

--- a/content/recruit/software_engineer/index.md
+++ b/content/recruit/software_engineer/index.md
@@ -5,8 +5,8 @@ date = 2025-07-18
 template = "job_post.html"
 +++
 # 募集中
-## **ソフトウェアエンジニア (Software Engineer)**
-## **勤務地：**
+## ソフトウェアエンジニア (Software Engineer)
+## 勤務地：
 本社（日本国内のみリモート勤務可）
 ---
 ### 雇用形態

--- a/sass/_about_company.scss
+++ b/sass/_about_company.scss
@@ -47,20 +47,8 @@
 	font-weight: 900;
 	text-align: left;
 	margin: 0;
-	-webkit-text-stroke: 2px white;
 	text-stroke: 2px white;
 	letter-spacing: 0.1em;
-	text-shadow:
-		0 0 0 white,
-		0 0 0 white,
-		0 0 0 white,
-		0 0 0 white,
-		0 0 0 white,
-		0 0 0 white,
-		0 0 0 white,
-		0 0 0 white,
-		0 0 0 white,
-		0 0 0 white;
 
 	/* Tablet */
 	@media (max-width: 991px) and (min-width: 768px) {
@@ -95,7 +83,7 @@
 .about-company-left__slogan {
 	font-family: 'Montserrat', 'Zen Kaku Gothic New', sans-serif;
 	font-size: 0.9em;
-	font-weight: 700;
+	font-weight: 600;
 	text-align: left;
 	color: white;
 	margin: 0;
@@ -172,7 +160,7 @@
 }
 
 .about-company-bold {
-	font-weight: 700;
+	font-weight: 600;
 }
 
 .about-company-gap {

--- a/sass/_application_form.scss
+++ b/sass/_application_form.scss
@@ -15,7 +15,7 @@
 			color: #fff;
 			font-size: 2.75rem;
 			margin-bottom: 0.25rem;
-			font-weight: bold;
+			font-weight: 600;
 		}
 
 		.application-form__subtitle {
@@ -28,7 +28,7 @@
 			color: #fff;
 			font-size: 1rem;
 			margin-top: 0.25rem;
-			font-weight: bold;
+			font-weight: 600;
 		}
 
 		.application-form__divider {

--- a/sass/_board_members.scss
+++ b/sass/_board_members.scss
@@ -22,7 +22,6 @@
 		margin: 0 0 0.2em;
 		color: white;
 		letter-spacing: 1px;
-		-webkit-text-stroke: 1px white;
 		text-stroke: 1px white;
 	}
 
@@ -39,7 +38,7 @@
 		font-family: 'Montserrat', 'Zen Kaku Gothic New', sans-serif;
 		color: white;
 		font-size: 1em;
-		font-weight: 700;
+		font-weight: 600;
 		margin-bottom: 0.4rem;
 		margin-top: 0;
 		opacity: 0.9;
@@ -96,7 +95,7 @@
 		font-family: 'Montserrat', 'Zen Kaku Gothic New', sans-serif;
 		font-size: 0.95em;
 		color: white;
-		font-weight: 700;
+		font-weight: 600;
 		margin-bottom: 0.3em;
 		letter-spacing: 0.5px;
 	}

--- a/sass/_docs_resources.scss
+++ b/sass/_docs_resources.scss
@@ -16,7 +16,7 @@
 
 .docs-resource-title {
 	font-size: 0.95rem;
-	font-weight: 700;
+	font-weight: 600;
 	color: #fff;
 }
 

--- a/sass/_footer.scss
+++ b/sass/_footer.scss
@@ -68,7 +68,7 @@
 
 		.company-name {
 			font-size: 1.25rem;
-			font-weight: bold;
+			font-weight: 550;
 			color: black;
 
 			@media (min-width: 3840px) {
@@ -146,6 +146,7 @@
 
 		a {
 			flex: 1;
+			font-weight: 550;
 			transition: var(--transition);
 			border-radius: 999px;
 			padding: 0.375rem 0.75rem;

--- a/sass/_hero_element.scss
+++ b/sass/_hero_element.scss
@@ -61,7 +61,6 @@
 				margin-bottom: 0.2em;
 				font-family: 'Montserrat', 'Zen Kaku Gothic New', sans-serif;
 				letter-spacing: 0.1em;
-				-webkit-text-stroke: 3px rgb(255, 255, 255);
 				white-space: nowrap;
 			}
 
@@ -76,7 +75,7 @@
 
 			p {
 				font-size: 0.6em;
-				font-weight: 700;
+				font-weight: 600;
 				color: #fff;
 				margin: 0;
 				margin-bottom: 0.5em;
@@ -140,7 +139,7 @@
 			text-align: left;
 			color: #f77d06;
 			font-size: 1em;
-			font-weight: 800;
+			font-weight: 600;
 			margin: 0;
 			margin-right: 1rem;
 			margin-left: 0;
@@ -225,7 +224,7 @@
 		h2 {
 			color: white;
 			font-size: 1.4em;
-			font-weight: 900;
+			font-weight: 500;
 			margin: 0;
 			text-transform: uppercase;
 			letter-spacing: 0.05em;

--- a/sass/_jobs_list.scss
+++ b/sass/_jobs_list.scss
@@ -19,7 +19,7 @@
 			font-size: 2.75rem;
 			margin-bottom: 0.1rem;
 			line-height: 1.1;
-			font-weight: bold;
+			font-weight: 600;
 		}
 
 		p.jobs-list__subtitle {
@@ -32,7 +32,7 @@
 			margin: 0;
 			font-size: 1rem;
 			color: #fff;
-			font-weight: bold;
+			font-weight: 600;
 		}
 
 		.jobs-list__divider {
@@ -106,6 +106,7 @@
 			}
 
 			&__recruiting-label {
+				font-weight: 500;
 				margin-top: 0.5rem;
 				color: #f77d06;
 				font-size: 0.9rem;

--- a/sass/_language_switcher.scss
+++ b/sass/_language_switcher.scss
@@ -16,7 +16,7 @@
 	// Simple text button styles
 	padding: 2px 6px;
 	border-radius: 3px;
-	font-weight: 500;
+	font-weight: 400;
 	text-align: center;
 	text-decoration: none;
 	background-color: transparent;

--- a/sass/_nav.scss
+++ b/sass/_nav.scss
@@ -132,7 +132,7 @@
 
 		.main-navbar-link {
 			font-size: 0.95rem;
-			font-weight: 700;
+			font-weight: 600;
 			color: white;
 			padding: 8px 10px;
 			border-radius: 999px;
@@ -166,7 +166,7 @@
 
 		#home a {
 			color: var(--fg-muted-5);
-			font-weight: 800;
+			font-weight: 500;
 
 			&:hover {
 				color: var(--fg-color);
@@ -179,7 +179,7 @@
 			background-color: #f77d06;
 			padding: 8px 24px;
 			border-radius: 999px;
-			font-weight: 700;
+			font-weight: 600;
 			text-decoration: none;
 			display: inline-flex;
 			align-items: center;

--- a/sass/_news_article.scss
+++ b/sass/_news_article.scss
@@ -13,7 +13,7 @@
 
 	.news-article-title {
 		font-size: 2em;
-		font-weight: 700;
+		font-weight: 600;
 		text-align: left;
 		margin-bottom: 2em;
 	}

--- a/sass/_prefooter.scss
+++ b/sass/_prefooter.scss
@@ -93,7 +93,6 @@
 		margin-top: 0;
 		line-height: 1.1;
 		letter-spacing: 0.1em;
-		-webkit-text-stroke: 3px rgb(255, 255, 255);
 
 		@media (max-width: 1024px) {
 			font-size: 2.6rem !important;
@@ -154,7 +153,7 @@
 	.card-footer-text {
 		font-size: 1.1rem !important;
 		line-height: 1.5;
-		font-weight: 500;
+		font-weight: 400;
 		margin-right: 80px;
 
 		@media (max-width: 1024px) {

--- a/sass/_price.scss
+++ b/sass/_price.scss
@@ -28,7 +28,7 @@
 
 	&__title {
 		font-size: 1.7em;
-		font-weight: 700;
+		font-weight: 600;
 		text-align: left;
 		flex-shrink: 0;
 		line-height: 1.2;
@@ -54,7 +54,7 @@
 
 	&__amount-number {
 		font-size: 2.5em;
-		font-weight: 700;
+		font-weight: 500;
 		line-height: 1;
 		white-space: nowrap;
 		flex-shrink: 2;

--- a/sass/_price_supp.scss
+++ b/sass/_price_supp.scss
@@ -21,7 +21,7 @@
 
 	&__title {
 		font-size: 1.7em;
-		font-weight: 700;
+		font-weight: 600;
 		text-align: left;
 		flex-shrink: 0;
 		line-height: 1.2;

--- a/sass/_product_display.scss
+++ b/sass/_product_display.scss
@@ -87,6 +87,7 @@
 
 			.product-title {
 				font-size: 1.5rem;
+				font-weight: 400;
 				color: #fff;
 				letter-spacing: 0.08em;
 
@@ -183,7 +184,7 @@
 
 			.external-label {
 				font-size: 0.9rem;
-				font-weight: 700;
+				font-weight: 600;
 				white-space: nowrap;
 				letter-spacing: 0.08em;
 
@@ -234,7 +235,7 @@
 			flex-wrap: wrap;
 			gap: 1.25rem;
 			font-size: 1rem;
-			font-weight: 700;
+			font-weight: 600;
 			color: #ff7800;
 			margin-top: 2rem;
 
@@ -278,7 +279,7 @@
 }
 
 .meta-a {
-	font-weight: 700;
+	font-weight: 600;
 	color: #fff;
 	margin-right: 0;
 	min-width: 16em;

--- a/sass/_recruit_intro.scss
+++ b/sass/_recruit_intro.scss
@@ -12,7 +12,7 @@
 .recruit-intro-title {
 	color: white;
 	font-size: 1.75rem;
-	font-weight: 700;
+	font-weight: 600;
 	margin-bottom: 2.5rem;
 	width: 100%;
 }

--- a/sass/_sc-list.scss
+++ b/sass/_sc-list.scss
@@ -7,7 +7,7 @@
 	}
 
 	&__label {
-		font-weight: 700;
+		font-weight: 600;
 		color: white;
 		white-space: nowrap;
 		font-size: 0.9em;
@@ -19,6 +19,7 @@
 
 	&__link {
 		color: inherit;
+		font-weight: 500;
 		text-decoration: none;
 		transition: color 0.3s ease;
 		display: block;

--- a/sass/_splash.scss
+++ b/sass/_splash.scss
@@ -10,7 +10,7 @@
 		flex-shrink: 0;
 		writing-mode: vertical-rl;
 		font-size: 12pt;
-		font-weight: bold;
+		font-weight: 600;
 		letter-spacing: 0.2em;
 		text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.8);
 		color: white;

--- a/sass/_tagline.scss
+++ b/sass/_tagline.scss
@@ -8,7 +8,6 @@
 		letter-spacing: 0.05em;
 		margin-bottom: 0.5rem;
 		padding: 1rem 1rem;
-		-webkit-text-stroke: 1px rgb(255, 255, 255);
 	}
 
 	&-subtitle {
@@ -23,10 +22,9 @@
 
 		&-title {
 			font-size: 2.7em;
-			font-weight: 950;
+			font-weight: 600;
 			letter-spacing: 0.05em;
 			text-align: center;
-			-webkit-text-stroke: 1px rgb(255, 255, 255);
 		}
 
 		&-subtitle {

--- a/sass/_threecard.scss
+++ b/sass/_threecard.scss
@@ -57,7 +57,7 @@
 
 		.label-number {
 			font-size: 8rem;
-			font-weight: 300;
+			font-weight: 400;
 			color: #bbb;
 			line-height: 0.75;
 			height: 4rem;
@@ -165,7 +165,7 @@
 		&-cardright-content {
 			h2 {
 				font-size: 1.2em;
-				font-weight: 900;
+				font-weight: 500;
 				margin-bottom: 1.75rem;
 				padding-left: 1rem;
 				padding-right: 1rem;

--- a/sass/_title.scss
+++ b/sass/_title.scss
@@ -22,7 +22,6 @@
 	font-size: 3rem !important;
 	font-weight: 950 !important;
 	letter-spacing: 0.1em;
-	-webkit-text-stroke: 3px rgb(255, 255, 255);
 }
 
 .title-content h3 {
@@ -54,7 +53,7 @@
 .title-style-top {
 	color: white;
 	font-size: 0.5em;
-	font-weight: 500;
+	font-weight: 400;
 	margin-top: 6em;
 	margin-left: 0;
 	text-align: left;

--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -6,7 +6,7 @@ h5,
 h6 {
 	text-wrap: balance;
 	margin: 2rem 0 1rem;
-	font-weight: lighter;
+	font-weight: normal;
 	line-height: normal;
 	font-family: 'Montserrat', 'Zen Kaku Gothic New', sans-serif;
 	letter-spacing: -0.05em;
@@ -159,7 +159,7 @@ kbd:active {
 
 a {
 	color: var(--accent-color);
-	font-weight: bold;
+	font-weight: 600;
 	text-decoration-thickness: max(1px, 0.0625em);
 }
 

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -14,5 +14,5 @@
 	<link type="text/css" rel="stylesheet" href="{{ get_url(path='style.css') | safe }}" />
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=Montserrat&family=Zen+Kaku+Gothic+New&display=swap" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300..700&family=Zen+Kaku+Gothic+New:wght@300..700&display=swap" rel="stylesheet">
 </head>


### PR DESCRIPTION
## Changes

Fix text anomaly seen when using -webkit-text-stroke above 2px. Solution is to update font weight import in head.html following Google CSS API, then remove -webkit-text-stroke in problematic blocks.

Also revise font-weight in some scss files to approximate initial design. Webkit-text-stroke was used to make text bolder, but also changed letter shape.

## Issue
This fixes #147 

## Visual

Webkit altered the shape of the letters. Removing webkit returned some text to native size.

[Screencast from 2025-08-08 12-34-05.webm](https://github.com/user-attachments/assets/6db7548f-cb1f-42d1-8ff2-27ff5862759a)

