### PR TITLE
templates: shortcodes: Fix get_url language handling with "@/”

### DIFF
--- a/templates/shortcodes/hero_element.html
+++ b/templates/shortcodes/hero_element.html
@@ -27,7 +27,7 @@
 				{% if link and link_text %}
 					<div class="link-wrapper">
 						<span class="link-text">{{ link_text }}</span>
-						<a href="{{ get_url(path=link) }}" class="hero-link"></a>
+						<a href="{{ get_url(path=link, lang=lang) }}" class="hero-link"></a>
 					</div>
 				{% endif %}
 			</div>

--- a/templates/shortcodes/product_display.html
+++ b/templates/shortcodes/product_display.html
@@ -58,7 +58,7 @@
 		{% if details_link %}
 			<div class="product-details">
 				Details
-				<a href="{{ get_url(path=details_link) }}" class="details-button" aria-label="View details">
+				<a href="{{ get_url(path=details_link, lang=lang) }}" class="details-button" aria-label="View details">
 					<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
 						<path d="M9 6l6 6-6 6" stroke="white" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
 					</svg>


### PR DESCRIPTION
get_url behaves differently depending on the "@/” prefix: without it, it uses the site’s default language from the config; with it, it does not. After 812101c55ce58d6 switched local links to "@/”, internal page links started resolving to the wrong language and broke.

Make the shortcode resolve links consistently regardless of the prefix.

This fixes #170.