### PR TITLE
docs: clarify linking to local pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,29 @@ one in the `date` variable. We haven’t been able to remove the
 redundant `date` field due to a limitation in Zola. See issue #114 for
 details.
 
+### Linking to Local Pages
+
+A link to a local page must include the `@/` prefix.
+
+In your `.md` file, create a link like this:
+
+```
+[here](@/products/scobc_a1.md)
+```
+
+Or, if you are calling one of our shortcodes:
+
+```
+{% hero_element(
+    title = "PRODUCTS",
+    link = "@/products/_index.md",
+    link_text = "Details"
+) %}
+```
+
+This ensures the correct link is generated for the page, based on its
+language.
+
 ## 🏗️ Project Structure
 
 This repository is organized into only a few main folders...

--- a/doc/develop.md
+++ b/doc/develop.md
@@ -28,6 +28,33 @@ The site uses custom shortcodes for reusable components.
 
 Examples on how to use these shortcodes on a page are shown below:
 
+### Templates
+#### Linking to Local Pages
+
+Use `get_url()` with the `@/` prefix and the current page's `lang`
+variable to link to local pages within the site.
+
+**Example of calling `get_url()` in a template or shortcode
+
+```html
+<a href="{{ get_url(path=link, lang=lang) }}">{{ link_text }}</a>
+```
+See [this PR](https://github.com/spacecubics/www/pull/158) for more details.
+
+We ask content writers to pass in a local link with "@/" prefix.
+
+```
+{% hero_element(
+    title = "PRODUCTS",
+    link = "@/products/_index.md",
+    link_text = "Details"
+) %}
+```
+
+Shortcode and template authors must handle local links with
+`get_url()` to generate the correct URL.
+
+
 #### Hero Elements
 ```html
 {% hero_element(
@@ -78,25 +105,6 @@ prefooter_cards = ["products/_index.md", "recruit/_index.md", "contact/_index.md
 
    Content here...
    ```
-
-### Linking to Other Content Pages
-
-Use `get_url()` with the `@/` prefix and the current page's `lang` variable to generate permalinks to content pages within the site.
-
-#### Example usage in markdown:
-```
-{% hero_element(
-    title = "PRODUCTS",
-    link = "@/products/_index.md",
-    link_text = "Details"
-) %}
-```
-
-#### Example usage in shortcode template:
-```html
-<a href="{{ get_url(path=link, lang=lang) }}">{{ link_text }}</a>
-```
-See [this PR](https://github.com/spacecubics/www/pull/158) for more details.
 
 ### Adding New News Articles
 1. Create a new file in `content/news/`


### PR DESCRIPTION
Add a new "Linking to Local Pages" section to README with examples for Markdown and shortcode usage.  Update `doc/develop.md` to include a corresponding section for template authors, explaining use of `get_url()` with the `@/` prefix and `lang` variable, and remove the outdated "Linking to Other Content Pages" section.

This updates #171.