### PR TITLE
feat: add 404 page to handle missing pages.

### DIFF
--- a/sass/_notfound.scss
+++ b/sass/_notfound.scss
@@ -1,63 +1,37 @@
-#notfound-image {
-	max-width: 100%;
-	height: auto;
-	display: block;
-	margin: 0 auto;
-}
+// 404 page styling
+.sc-404 {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 55px;
 
-.notfound-pixels {
-	image-rendering: pixelated;
-}
+    &__logo {
+        img {
+            max-width: 400px;
+            height: auto;
+        }
+    }
 
-.notfound-transparent {
-	opacity: 0.85;
-}
+    &__message {
+        font-size: 1.5rem;
+        font-weight: 500;
+        margin-bottom: 55px;
+    }
 
-.notfound-no-hover:hover {
-	opacity: 1;
-}
+    &__button {
+        display: inline-block;
+        padding: 0.75rem 1.5rem;
+        background-color: transparent;
+        text-decoration: none;
+        border: 2px solid #ffffff;
+        border-radius: 10px;
+        transition: all 0.3s ease;
+        font-weight: 500;
 
-.notfound-title {
-	font-size: 2.5rem;
-	text-align: center;
-	margin-top: 1.5rem;
-	color: #e63946; // Customize as needed
-}
-
-.notfound-message {
-	font-size: 1.1rem;
-	text-align: center;
-	margin: 1rem auto 2rem auto;
-	max-width: 600px;
-	color: #555;
-}
-
-.notfound-buttons {
-	display: flex;
-	justify-content: center;
-	gap: 1rem;
-	flex-wrap: wrap;
-	margin-bottom: 3rem;
-}
-
-.notfound-button {
-	background-color: #1d3557;
-	color: #fff;
-	padding: 0.6rem 1.2rem;
-	border-radius: 5px;
-	text-decoration: none;
-	font-weight: 600;
-	transition: background-color 0.3s ease;
-
-	&:hover {
-		background-color: #457b9d;
-	}
-
-	&.notfound-colored {
-		background-color: #e63946;
-
-		&:hover {
-			background-color: #d62839;
-		}
-	}
+        &:hover {
+            background-color: #ff7800;
+        }
+    }
 }

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<head>
+    <title>404 - Page Not Found</title>
+    <link rel="stylesheet" href="{{ get_url(path='style.css') }}">
+</head>
+<body>
+    <div class="sc-404">
+        <div class="sc-404__logo">
+            <img src="{{ get_url(path='logo_black.webp') }}" alt="Space Cubics Logo">
+        </div>
+        <h1>404</h1>
+        <div class="sc-404__message">Page Not Found</div>
+        <a href="{{ get_url(path='/') }}" class="sc-404__button">Back to Home</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Add 404.html to /templates directory as well as associated _notfound.scss. Default 404.html template only has access to config.toml context. Therefore, style.css is referenced in <head> section.

This fixes #165 

Visual:

<img width="455" height="430" alt="Screenshot from 2025-08-12 14-27-16" src="https://github.com/user-attachments/assets/8365a026-9a05-4632-9e31-f5ebe47cf2b5" />
