### PR TITLE
docs: editorconfig: use spaces instead of tabs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,6 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_size = 2
-indent_style = tab
+indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/doc/develop.md
+++ b/doc/develop.md
@@ -12,6 +12,11 @@
 - **Deployment**: Cloudflare Pages with Workers
 - **Forms**: Cloudflare Turnstile CAPTCHA + Slack integration
 
+## Indentation
+- **Use spaces, not tabs** for indentation
+- **2 spaces** per indentation level
+- This is configured in `.editorconfig` and should be followed by all contributors
+
 ## Design System
 ### Color Scheme
 This site is designed with white text on a navy blue (primary color) background.


### PR DESCRIPTION
Change .editorconfig to use space indentation rather than tabs. Add Indentation section to develop.md for other members. Do not apply new style to project in this commit.

This fixes #194 