### PR TITLE
macro: translate: remove unused date_locale variable

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,3 +1,2 @@
 language_name = "English"
 date_format = "%B %d, %Y"
-date_locale = "en_US"

--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -1,3 +1,2 @@
 language_name = "日本語"
 date_format = "%Y年%m月%d日"
-date_locale = "ja_JP"

--- a/templates/article.html
+++ b/templates/article.html
@@ -21,13 +21,13 @@
 					<small>
 						<time datetime="{{ page.date | date(format='%+') }}">
 							{{ macros_translate::translate(key="published", default="Published on", language_strings=language_strings) }}
-							{{ page.date | date(locale=date_locale) }}
+							{{ page.date }}
 						</time>
 						{%- if page.updated %}
 							<span> {{ config.extra.separator | default(value="•") }} </span>
 							<time datetime="{{ page.updated | date(format='%+') }}">
 								{{ macros_translate::translate(key="updated", default="Updated on", language_strings=language_strings) }}
-								{{ page.updated | date(locale=date_locale) }}
+								{{ page.updated }}
 							</time>
 						{%- endif %}
 					</small>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,6 @@
 {% import "macros/rel_attributes.html" as macros_rel_attributes %}
 {% import "macros/translate.html" as macros_translate %}
 {%- set language_strings = load_data(path="i18n/" ~ lang ~ ".toml", required=false) -%}
-{%- set date_locale = macros_translate::translate(key="date_locale", default="en_US", language_strings=language_strings) -%}
 {%- set date_format = macros_translate::translate(key="date_format", language_strings=language_strings) -%}
 
 

--- a/templates/partials/articles.html
+++ b/templates/partials/articles.html
@@ -18,7 +18,7 @@
 				<div class="details">
 					<small>
 						<time datetime="{{ page.date | date(format='%+') }}" pubdate>
-							{{- page.date | date(locale=date_locale) -}}
+							{{- page.date  -}}
 						</time>
 					</small>
 				</div>


### PR DESCRIPTION
Remove references to the unused variable `date_locale` associated with the macro `translate.html`. 

These references remain from a previous version of the macro, and their removal does not affect date format translation.

This fixes #58 and is associated with https://github.com/spacecubics/www/pull/141.
