### PR TITLE
_svg-icon.scss: move sns icon format control to dedicated file

### DIFF
--- a/sass/_footer.scss
+++ b/sass/_footer.scss
@@ -228,19 +228,6 @@
 				transform: var(--active);
 			}
 
-			.icon {
-				-webkit-mask-image: var(--icon);
-				mask-image: var(--icon);
-				transition: var(--transition);
-				width: 2.5rem;
-				height: 2.5rem;
-
-				@media (min-width: 3840px) {
-					width: 4rem;
-					height: 4rem;
-				}
-			}
-
 			span {
 				display: none;
 			}

--- a/sass/_splash.scss
+++ b/sass/_splash.scss
@@ -117,12 +117,6 @@
 	opacity: 0.3;
 }
 
-.social-icons .icon {
-	mask-image: var(--icon);
-	width: 100%;
-	height: 100%;
-}
-
 @keyframes floatDown {
 	0%, 100% {
 		transform: translateY(0);
@@ -180,10 +174,6 @@
 		height: 5.4rem;
 	}
 
-	.social-icons .icon {
-		width: 100%;
-		height: 100%;
-	}
 	.social-label {
 		font-size: 3rem;
 	}

--- a/sass/_svg-icon.scss
+++ b/sass/_svg-icon.scss
@@ -1,0 +1,29 @@
+.svg-icon {
+	mask-image: var(--icon);
+	transition: var(--transition);
+	background-color: currentColor;
+	display: inline-block;
+	width: var(--icon-size);
+	height: var(--icon-size);
+	flex-shrink: 0;
+
+	&--splash {
+		color: white;
+		--icon-size: 29px;
+	}
+
+	&--footer {
+		color: rgb(58, 55, 90);
+		--icon-size: 40px;
+
+		&:hover {
+			color: var(--accent-color);
+		}
+	}
+
+	&--youtube {
+		width: var(--icon-width, var(--icon-size));
+		height: var(--icon-height, var(--icon-size));
+		vertical-align: middle;
+	}
+}

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -18,7 +18,7 @@
 @use "general";
 @use "hero_element";
 @use "hidden";
-@use "icon";
+@use "svg-icon";
 @use "iframe";
 @use "input";
 @use "job_post";

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -73,7 +73,11 @@
 					{%- for link in config.extra.footer.socials %}
 						<li>
 							<a href="{{ link.url | safe }}" rel="{{ rel_attributes }} me" title="{{ link.name }}">
-								<i class="icon" style='--icon: url("data:image/svg+xml,{{ link.icon }}")'></i>
+								{% if link.name == "YouTube" %}
+									<i class="svg-icon svg-icon--footer svg-icon--youtube" style='--icon: url("data:image/svg+xml,{{ link.icon }}"); --icon-width: 40px; --icon-height: 40px'></i>
+								{% else %}
+									<i class="svg-icon svg-icon--footer" style='--icon: url("data:image/svg+xml,{{ link.icon }}")'></i>
+								{% endif %}
 								<span>{{ link.name }}</span>
 							</a>
 						</li>

--- a/templates/shortcodes/splash.html
+++ b/templates/shortcodes/splash.html
@@ -12,7 +12,11 @@
 			{%- if config.extra.footer.socials %}
 				{%- for link in config.extra.footer.socials %}
 					<a href="{{ link.url }}" target="_blank" rel="noopener" title="{{ link.name }}">
-						<i class="icon" style='--icon: url("data:image/svg+xml,{{ link.icon }}")'></i>
+						{% if link.name == "YouTube" %}
+							<i class="svg-icon svg-icon--splash svg-icon--youtube" style='--icon: url("data:image/svg+xml,{{ link.icon }}"); --icon-width: 29px; --icon-height: 29px'></i>
+						{% else %}
+							<i class="svg-icon svg-icon--splash" style='--icon: url("data:image/svg+xml,{{ link.icon }}")'></i>
+						{% endif %}
 					</a>
 				{%- endfor %}
 			{%- endif %}


### PR DESCRIPTION
Create _svg-icon.scss to handle svg icon formatting in footer and splash elements. splash.html and footer.html now use the new svg-icon class, which uses a block-modifier design.

This fixes #86 