### PR TITLE
fix: add absent link block to partners.html

### DIFF
--- a/templates/shortcodes/partners.html
+++ b/templates/shortcodes/partners.html
@@ -15,6 +15,14 @@
 			<div class="partner__content">
 				<h3 class="partner__name">{{ name }}</h3>
 				<div class="partner__desc">{{ body | markdown | safe }}</div>
+				{% if link %}
+          <a href="{{ link }}" class="external-link">
+            <span class="external-link__pair">
+              <span class="external-link__label">More</span>
+              <img src="/cil-external-link.svg" class="external-link__icon"/>
+            </span>
+          </a>
+				{% endif %}
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Changes

Add <a> block for partners.html `link` argument, which is currently included in about_us markdown files but not used. Style is taken from `_external_links.scss`.

## Fixes
This fixes #197 

## Visual

### Before:

<img width="1138" height="344" alt="image" src="https://github.com/user-attachments/assets/ae1f9480-6181-482f-9624-25afb4a256f2" />

### After:

<img width="1138" height="344" alt="image" src="https://github.com/user-attachments/assets/c0b2c2ae-3621-4f9c-867f-fdc549ca86de" />
