### PR TITLE
docs: scobc-a1: add software manual link

### DIFF
--- a/content/products/scobc_a1.en.md
+++ b/content/products/scobc_a1.en.md
@@ -132,10 +132,10 @@ information.
 		subtitle="",
 		slogan=""
 	) %}
-	Product Manual | This is the specification docuement of SC-OBC Module A1. It describes communication systems, circuit configurations, and more. | https://spacecubics.github.io/sc-docs/scobc-a1-product-manual/latest/product_manual_en.html
-  Software Manual | This document is a step-by-step guide for setting up the development environment, flashing, and running Zephyr-based applications on the SC-OBC Module A1. | https://spacecubics.github.io/sc-docs/scobc-a1-software-manual/latest/index.html
-	FPGA Technical Reference Manual | This is the specification document for the FPGA implemented on the SC-OBC Module A1. It describes the FPGA functions and register specifications required for FPGA development and software development. | https://spacecubics.github.io/sc-docs/scobc-a1-fpga-technical-reference-manual/latest/index.html
+	Product Manual | This is our specification document for SC-OBC Module A1. It describes communication systems, circuit configurations, and more. | https://spacecubics.github.io/sc-docs/scobc-a1-product-manual/latest/product_manual_en.html
+  Software Manual | This document is a step-by-step guide for setting up the development environment, flashing, and running Zephyr-based applications on SC-OBC Module A1. | https://spacecubics.github.io/sc-docs/scobc-a1-software-manual/latest/index.html
+	FPGA Technical Reference Manual | This is the specification document for the FPGA used in SC-OBC Module A1. It describes the FPGA functions and register specifications required for FPGA and software development. | https://spacecubics.github.io/sc-docs/scobc-a1-fpga-technical-reference-manual/latest/index.html
 	Zephyr Info Page | This is the dedicated SC-OBC Module A1 page on the Zephyr Project site. | https://docs.zephyrproject.org/latest/boards/sc/scobc_a1/doc/index.html
-	GitHub | For other technical information, please refer to the following. | https://github.com/spacecubics
+	GitHub | For other technical information, please refer to our GitHub account. | https://github.com/spacecubics
 	{% end %}
 </section>

--- a/content/products/scobc_a1.en.md
+++ b/content/products/scobc_a1.en.md
@@ -133,6 +133,7 @@ information.
 		slogan=""
 	) %}
 	Product Manual | This is the specification docuement of SC-OBC Module A1. It describes communication systems, circuit configurations, and more. | https://spacecubics.github.io/sc-docs/scobc-a1-product-manual/latest/product_manual_en.html
+  Software Manual | This document is a step-by-step guide for setting up the development environment, flashing, and running Zephyr-based applications on the SC-OBC Module A1. | https://spacecubics.github.io/sc-docs/scobc-a1-software-manual/latest/index.html
 	FPGA Technical Reference Manual | This is the specification document for the FPGA implemented on the SC-OBC Module A1. It describes the FPGA functions and register specifications required for FPGA development and software development. | https://spacecubics.github.io/sc-docs/scobc-a1-fpga-technical-reference-manual/latest/index.html
 	Zephyr Info Page | This is the dedicated SC-OBC Module A1 page on the Zephyr Project site. | https://docs.zephyrproject.org/latest/boards/sc/scobc_a1/doc/index.html
 	GitHub | For other technical information, please refer to the following. | https://github.com/spacecubics

--- a/content/products/scobc_a1.md
+++ b/content/products/scobc_a1.md
@@ -118,6 +118,7 @@ SC-OBC Module A1と衛星を接続するための基板開発を受託します�
 		slogan=""
 	) %}
 	Product Manual | SC-OBC Module A1の仕様、通信系統、回路構成等について記載されています。 | https://spacecubics.github.io/sc-docs/scobc-a1-product-manual/latest/product_manual.html
+  Software Manual | SC-OBC Module A1上でZephyrのアプリケーションを開発・フラッシュ・実行するための環境構築および手順をまとめた技術マニュアルです。 | https://spacecubics.github.io/sc-docs/scobc-a1-software-manual/latest/index.html
 	FPGA Technical Reference Manual | SC-OBC Module A1に搭載されているFPGAの仕様書です。FPGAの開発や、ソフトウェアの開発に必要な、FPGA機能に関する仕様やレジスタの仕様が記載されています。 | https://spacecubics.github.io/sc-docs/scobc-a1-fpga-technical-reference-manual/latest/index.html
 	Zephyr Info Page | Zephyr Project 公式ドキュメントの、SC-OBC Module A1 ボード情報ページです。 | https://docs.zephyrproject.org/latest/boards/sc/scobc_a1/doc/index.html
 	GitHub | その他、様々な技術情報はこちらを参照ください。 | https://github.com/spacecubics


### PR DESCRIPTION
## Changes

Add link to software manual in JP and EN versions of scobc-a1 page.

## Fixes

This fixes #181 

## Visual

### Before

<img width="1152" height="629" alt="image" src="https://github.com/user-attachments/assets/aa240359-1659-48e8-8122-054f74741216" />

### After

<img width="1153" height="750" alt="image" src="https://github.com/user-attachments/assets/5358a3df-5983-4ec9-859b-b6874b1f4869" />
