### PR TITLE
fix: extend nav breakpoint to prevent horizontal scroll

### DIFF
--- a/sass/_nav.scss
+++ b/sass/_nav.scss
@@ -19,7 +19,6 @@
 			align-items: center;
 			justify-content: space-between;
 			flex-wrap: nowrap;
-
 		}
 
 		.nav-links-container {
@@ -88,7 +87,7 @@
 			flex-wrap: nowrap;
 			justify-content: flex-end;
 			align-items: flex-end;
-			gap: 3rem;
+			gap: 2rem;
 			margin-bottom: 50px;
 			list-style: none;
 			flex: 1 1 auto;


### PR DESCRIPTION
## Changes
Change mobile navigation breakpoint from 1000px to 1014px. 
This eliminates the horizontal scroll bar and prevents the contact button from being cut off.

## Fix

This fixes  #166 

## Visual

### Before

<img width="780" height="99" alt="image" src="https://github.com/user-attachments/assets/b18c2b69-6ad4-4d81-abc8-fc9b6b1cccdd" />

(one pixel before hamburger transition)

<img width="1001" height="166" alt="image" src="https://github.com/user-attachments/assets/e11f5ec6-4c66-4023-89ec-eee27eb23882" />


### After

<img width="780" height="99" alt="image" src="https://github.com/user-attachments/assets/92064fbe-635a-49a4-b681-84b13b297791" />

(one pixel before hamburger transition)

<img width="999" height="127" alt="image" src="https://github.com/user-attachments/assets/1401ee88-81bd-4563-bd7b-e73ca1a29e38" />