### PR TITLE
i18n: fix: Replace JA text in about_us.en.md

### DIFF
--- a/content/about_us.en.md
+++ b/content/about_us.en.md
@@ -20,7 +20,7 @@ card_body = "Aiming for an era where anyone can go to the moon, we are a JAXA ve
 	right_card="blocks/to_space.en.toml"
 ) }}
 
-{{ kv_list(line1="COMPANY", line2="Space Cubics", line3="OVERVIEW", data="blocks/about_company.json") }}
+{{ kv_list(line1="COMPANY", line2="Space Cubics", line3="OVERVIEW", data="blocks/about_company.en.json") }}
 
 {{ board_members(line1="BOARD MEMBER", line2="Executive", line3="PROFILES", members="blocks/board-members.en.json") }}
 {{ board_members(line1="FOUNDING ALUMNI", line2="", line3="", members="blocks/founding-alumni.en.json") }}


### PR DESCRIPTION
## Changes

Replace the Japanese text in the English About Us page by pointing to blocks/about_company.en.json.

## Fixes
This fixes #214 

## Visual

### Before 

<img width="1091" height="468" alt="image" src="https://github.com/user-attachments/assets/0fc822c3-91e1-4024-8703-6e1fc05d8bfc" />


### After 

<img width="1091" height="468" alt="image" src="https://github.com/user-attachments/assets/36ae0d88-0d93-4f48-a9e7-213fb97207fd" />
