### PR TITLE
Separate the form into a contact form and a recruitment form

### DIFF
--- a/functions/contact.js
+++ b/functions/contact.js
@@ -33,16 +33,22 @@ export const onRequestPost = async ({ request, env }) => {
 
 		const verifyJson = await verifyRes.json();
 
+		// Determine which webhook to use based on form ID
+		const webhookMap = {
+			"recruitForm": env.SLACK_WEBHOOK_RECRUIT,
+			"contactForm": env.SLACK_WEBHOOK_CONTACT
+		};
+		const slackWebhook = webhookMap[form_id];
+		const slackFormType = form_id === "recruitForm" ? "Recruitment" : "Contact";
+
+		if (!slackWebhook) {
+			return new Response(`Missing Slack webhook for ${slackFormType.toLowerCase()} form`, { status: 500 });
+		}
 
 		// Prepare Slack message
 		const slackMessage = {
-			text: `📬 *New Contact Form Submission:*\n*Name:* ${name}\n*Email:* ${email}\n*Role:* ${Array.isArray(role) ? role.join(", ") : role}\n*Message:* ${message}`,
+			text: `📬 *New ${slackFormType} Form Submission:*\n*Name:* ${name}\n*Email:* ${email}\n*Role:* ${role || "Not provided"}\n*Message:* ${message}`,
 		};
-
-		const slackWebhook = env.SLACK_WEBHOOK;
-		if (!slackWebhook) {
-			return new Response("Missing Slack webhook", { status: 500 });
-		}
 
 		const slackRes = await fetch(slackWebhook, {
 			method: "POST",

--- a/static/js/contact.js
+++ b/static/js/contact.js
@@ -30,6 +30,7 @@ document.addEventListener("DOMContentLoaded", function () {
 			role: formData.get("role"),
 			message: formData.get("message"),
 			website: formData.get("website"), // honeypot field
+			form_id: form.id,
 			captcha: captchaToken,
 		};
 

--- a/templates/shortcodes/application_form.html
+++ b/templates/shortcodes/application_form.html
@@ -10,7 +10,7 @@
 		</div>
 
 		<!-- Form with white border -->
-		<form id="contactForm" class="z-contact-form__form">
+		<form id="recruitForm" class="z-contact-form__form">
 			<p class="z-contact-form__field">
 				<label class="z-contact-form__label">
 					{{ name_field | default(value="Your Name") }}:


### PR DESCRIPTION
## Changes
- Revise `functions/contact.js` to use map of webhooks based on form ID.
- Revise `js/contact.js` to send `form_id` in payload.
- Revise `application_form.html` form id to `"recruitForm"`.

## Fixes
This fixes #200 