### PR TITLE
fix: broken contact and recruit forms after dual Slack hook implementation

### DIFF
--- a/functions/contact.js
+++ b/functions/contact.js
@@ -2,7 +2,7 @@ export const onRequestPost = async ({ request, env }) => {
 	try {
 		// Read and parse incoming JSON request
 		const body = await request.json();
-		const { name, email, role, message, website, captcha } = body;
+		const { name, email, role, message, website, captcha, form_id } = body;
 
 		// Honeypot anti-spam check
 		if (website && website.trim() !== "") {

--- a/static/js/contact.js
+++ b/static/js/contact.js
@@ -1,6 +1,12 @@
 document.addEventListener("DOMContentLoaded", function () {
-	const form = document.getElementById("contactForm");
+	const form = document.getElementById("contactForm") || document.getElementById("recruitForm");
 	const submitBtn = document.getElementById("submitBtn");
+
+		// Check if form exists
+	if (!form) {
+		console.warn("Contact form not found on this page");
+		return;
+	}
 
 	let captchaToken = null;
 


### PR DESCRIPTION
## Changes

1. Add `form_id` to `body` variable in `functions/contact.js`
2. Handle both `contactForm` and `recruitForm` IDs in `js/contact.js`

## Fixes

This PR addresses issues which arose from commit b31bb911ef79768b20db1a529d6276fc88585545.

Errors:
1. contact form returned 500 error for `form_id` in payload.
3. recruit form was unresponsive.

## Testing

PR deployment branches used to confirm `contact form` and `recruit form` delivery.