### PR TITLE
.cloudflare-build.sh: Use ```CF_PAGES_URL``` in preview builds

### DIFF
--- a/.cloudflare-build.sh
+++ b/.cloudflare-build.sh
@@ -5,4 +5,8 @@ ZOLA_ARCHIVE="https://github.com/getzola/zola/releases/download/v${ZOLA_VERSION}
 
 curl -sL "$ZOLA_ARCHIVE" | tar -xz
 
-./zola build
+if [ "$CF_PAGES_BRANCH" != "main" ]; then
+  OPT="--base-url $CF_PAGES_URL"
+fi
+
+./zola build $OPT


### PR DESCRIPTION
We want to set base URL as ```https://<hash>.spacecubics.pages.dev``` in preview builds.
This method is described at the following page:

https://developers.cloudflare.com/pages/framework-guides/deploy-a-zola-site/