### PR TITLE
package.json: Add Playwright scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "scripts": {
+    "update-snapshots": "playwright test --update-snapshots",
+    "test": "playwright test"
+  },
   "devDependencies": {
     "@playwright/test": "^1.55.0",
     "@types/node": "^24.3.0"


### PR DESCRIPTION
Add Playwright commands to the "scripts" section in package.json to enable running:

    npm run update-snapshots
    npm run test

Since our GitHub Action for Playwright checks out the merge base, this change should be merged first without modifying the GitHub Action itself.

Blocked by #255 