### PR TITLE
ci: vrt: add PR commenter workflow

### DIFF
--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -3,6 +3,10 @@ name: Visual Regression Test
 on:
   pull_request
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -75,7 +79,6 @@ jobs:
       - name: Run visual regression test
         run: npx playwright test tests/visual-regression-test.spec.ts
         continue-on-error: true
-        id: vrt-test
 
       - name: Stop PR server
         run: pkill -f "python3 -m http.server"
@@ -87,15 +90,3 @@ jobs:
             test-results/
             playwright-report/
           retention-days: 30
-
-      - name: Comment on PR if test failed
-        if: steps.vrt-test.outcome == 'failure'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '⚠️ **VRT Failure**\n\nDownload the CI artifact to view details.'
-            })

--- a/sass/_nav.scss
+++ b/sass/_nav.scss
@@ -10,6 +10,7 @@
 	inset-inline: 0;
 	overflow: visible;
 	overflow-x: auto;
+  border: 1px solid red;
 
 	nav {
 		font-size: inherit;


### PR DESCRIPTION
Remove PR commenter step from visual-regression-test.yml. Add vrt-commenter.yml to detect VRET failure and generate warning.

This commit fixes the GITHUB_TOKEN read-only permission issue encountered when a PR originates from a forked repository.