### PR TITLE
VRT: allow PR comment from forks (set issues: write)

### DIFF
--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -3,6 +3,10 @@ name: Visual Regression Test
 on:
   pull_request
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add top-level permissions to workflow to enable PR warnings on forked PRs using actions/github-script.\n- Set contents: read, issues: write.\n\nThis unblocks cross-origin PRs where GITHUB_TOKEN defaults to read-only.