### PR TITLE
README: fix unintended list caused by wrapped hyphen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Space Cubics Website
 
-This is a corporate website built with [Zola](https://www.getzola.org/)
-- a static site generator written in Rust.
+This is a corporate website built with [Zola](https://www.getzola.org/) --
+a static site generator written in Rust.
 
 ## 🚀 Quick Start
 


### PR DESCRIPTION
A long line was wrapped so the second line began with "- ", which Markdown parsed as a list item and changed the meaning. Reflow the sentence and use " -- " before "a static site generator..." to keep the punctuation without triggering list syntax.