### PR TITLE
Fix Playwright homepage snapshot width problem

### DIFF
--- a/sass/_general.scss
+++ b/sass/_general.scss
@@ -92,3 +92,7 @@ body {
 html, body {
 	overflow-x: hidden;
 }
+
+* {
+	max-width: 100vw;
+}


### PR DESCRIPTION
Fix excess right-side space on homepage snapshots that occurs when Playwright `fullPage` is set to `true`.