### PR TITLE
tests: vrt: news: Enlarge viewport for long news entry

### DIFF
--- a/tests/visual-regression-test.spec.ts
+++ b/tests/visual-regression-test.spec.ts
@@ -62,6 +62,7 @@ test.describe('Visual Regression Tests', () => {
   });
 
   test('individual news article comparison (complex)', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 2200 });
     await page.goto('/news/2025-09-04/');
     await page.waitForLoadState('load');
     await expect(page).toHaveScreenshot();


### PR DESCRIPTION
The large news page doesn't fit within the default 1280x720 viewport. Increase the height to 1280x2200 to accommodate longer entries.

This works around #264 for #260 
