### PR TITLE
doc: develop: Update Playwright section with VRT details

### DIFF
--- a/doc/develop.md
+++ b/doc/develop.md
@@ -148,7 +148,8 @@ Required for contact form functionality:
 - `SLACK_WEBHOOK`: Slack webhook URL for notifications
 
 ## Playwright Integration
-We use [Playwright](https://playwright.dev/) for CI testing.
+We use [Playwright](https://playwright.dev/) for Visual Regression
+Test (VRT).
 
 #### Configuration
 Playwright is configured via `playwright.config.ts`.
@@ -158,6 +159,9 @@ This file can be expanded to define test variables (URLs), and web server detail
 - `npx playwright test` - Run all tests in `tests/` directory
 - `npx playwright test --update-snapshots` - Update reference screenshots
 - `npx playwright show-report /path/to/playwright-report/` - View test results
+
+We do not keep reference screenshots in the repository. Therefore, you
+need to generate them first before running the actual tests.
 
 #### Use with CI
 We use GitHub workflows to automate tests.


### PR DESCRIPTION
Clarify that Playwright is used for Visual Regression Testing (VRT) rather than just CI testing. Add a note that reference screenshots are not stored in the repository and must be generated locally before running tests.