### PR TITLE
scss: add overflow-x: hidden; to exceptions in _general.scss

### DIFF
--- a/sass/_general.scss
+++ b/sass/_general.scss
@@ -34,24 +34,28 @@ body {
 .hero-section {
 	margin-left: calc(-50vw + 50%);
 	margin-right: calc(-50vw + 50%);
+  overflow-x: hidden;
 }
 
 // Splash section exception - allow full width background
 .splash {
 	margin-left: calc(-50vw + 50%);
 	margin-right: calc(-50vw + 50%);
+  overflow-x: hidden;
 }
 
 // Banner section exception - allow full width background
 .banner {
 	margin-left: calc(-50vw + 50%);
 	margin-right: calc(-50vw + 50%);
+  overflow-x: hidden;
 }
 
 // Footer exception - allow full width background
 #site-footer {
 	margin-left: calc(-50vw + 50%);
 	margin-right: calc(-50vw + 50%);
+  overflow-x: hidden;
 }
 
 ::selection {


### PR DESCRIPTION
## Task
Hide x-axis overflow for hero-section, splash, banner, and site-footer in _general.scss.

## Fixes
This fixes the extra right-side space in homepage `fullPage` snapshots

## VRT Failures
- Homepage snapshots fail as expected.
- Mobile snapshots unaffected.

<img width="1022" height="519" alt="image" src="https://github.com/user-attachments/assets/141aa3be-d828-4e69-8877-a1f618d82a0c" />
