### PR TITLE
templates, content: Use variable for price title instead of fixed text

### DIFF
--- a/content/products/scobc_a1.en.md
+++ b/content/products/scobc_a1.en.md
@@ -79,7 +79,7 @@ even terrestrial applications here on Earth.
 
 {{ section_title(title="PRICE", subtitle="", slogan="") }}
 
-{% price(price_number="300,000", price_unit="JPY (excluding tax)", price_note="*This price is a limited-time offer.") %}
+{% price(price_title="SC-OBC Module A1", price_number="300,000", price_unit="JPY (excluding tax)", price_note="*This price is a limited-time offer.") %}
 
 The SC-OBC Module A1 is scheduled to undergo space-readiness testing
 using a satellite we developed in-house. This price is only available

--- a/content/products/scobc_a1.md
+++ b/content/products/scobc_a1.md
@@ -76,7 +76,7 @@ Xilinx製 Artix-7 FPGAを採用し、インターフェースの種類や数を�
 
 {{ section_title(title="PRICE", subtitle="", slogan="") }}
 
-{% price(price_number="30", price_unit="万円(税別)", price_note="※本価格は期間限定の特別価格となります。") %}
+{% price(price_title="SC-OBC Module A1", price_number="30", price_unit="万円(税別)", price_note="※本価格は期間限定の特別価格となります。") %}
 SC-OBC Module A1（以下、「本製品」と表記します）は自社開発衛星による宇宙実証を予定しております。本価格は宇宙実証までの期間限定の特別価格となります。特別価格が適用される条件は以下のとおりです。
 
 - 本製品を購入いただいたことを弊社ホームページやSNS等で公開することを許諾いただきます。

--- a/templates/shortcodes/price.html
+++ b/templates/shortcodes/price.html
@@ -2,7 +2,7 @@
 	<div class="price__container">
 		<div class="price__left">
 			<div class="price__title-row">
-				<div class="price__title">SC-OBC Module A1</div>
+				<div class="price__title">{{ price_title }}</div>
 				<div class="price__amount">
 					<span class="price__amount-number">{{ price_number }}</span>
 					<span class="price__amount-unit">{{ price_unit }}</span>


### PR DESCRIPTION
Previously, the price shortcode had a fixed title text that couldn’t be customized. 
This change allows each shortcode instance to define its own title through a parameter.