### PR TITLE
content: recruit: Sort job position cards by date

### DIFF
--- a/content/recruit/_index.en.md
+++ b/content/recruit/_index.en.md
@@ -3,6 +3,7 @@ title = "RECRUIT"
 description = "Employment information"
 template = "recruit_section.html"
 page_template = "job_post.html"
+sort_by = "date"
 
 [extra]
 background_image = "earth.jpg"

--- a/content/recruit/_index.md
+++ b/content/recruit/_index.md
@@ -3,6 +3,7 @@ title = "RECRUIT"
 description = "採用情報"
 template = "recruit_section.html"
 page_template = "job_post.html"
+sort_by = "date"
 
 [extra]
 background_image = "earth.jpg"

--- a/content/recruit/communications.en.md
+++ b/content/recruit/communications.en.md
@@ -1,5 +1,6 @@
 +++
 title = "Communications Engineer"
+date = 2020-02-01
 
 [extra]
 active = false

--- a/content/recruit/communications.md
+++ b/content/recruit/communications.md
@@ -1,5 +1,6 @@
 +++
 title = "通信エンジニア"
+date = 2020-02-01
 
 [extra]
 active = false

--- a/content/recruit/engineering-assistant.md
+++ b/content/recruit/engineering-assistant.md
@@ -1,5 +1,6 @@
 +++
 title = "技術アシスタント"
+date = 2020-01-14
 
 [extra]
 active = false

--- a/content/recruit/fpga.en.md
+++ b/content/recruit/fpga.en.md
@@ -1,5 +1,6 @@
 +++
 title = "FPGA Engineer"
+date = 2020-04-01
 
 [extra]
 active = false

--- a/content/recruit/fpga.md
+++ b/content/recruit/fpga.md
@@ -1,5 +1,6 @@
 +++
 title = "FPGA エンジニア"
+date = 2020-04-01
 
 [extra]
 active = false

--- a/content/recruit/hardware.en.md
+++ b/content/recruit/hardware.en.md
@@ -1,5 +1,6 @@
 +++
 title = "Hardware Engineer"
+date = 2020-03-01
 
 [extra]
 active = false

--- a/content/recruit/hardware.md
+++ b/content/recruit/hardware.md
@@ -1,5 +1,6 @@
 +++
 title = "ハードウェアエンジニア"
+date = 2020-03-01
 
 [extra]
 active = false

--- a/content/recruit/sales.en.md
+++ b/content/recruit/sales.en.md
@@ -1,5 +1,6 @@
 +++
 title = "Sales"
+date = 2020-01-01
 
 [extra]
 active = false

--- a/content/recruit/sales.md
+++ b/content/recruit/sales.md
@@ -1,5 +1,6 @@
 +++
 title = "営業"
+date = 2020-01-01
 
 [extra]
 active = false


### PR DESCRIPTION
Add `sort_by = "date"` to recruit index pages and specify `date` fields in each job post to enable consistent ordering. Without sorting, position cards shuffle on each build, causing VRT to fail even when there are no actual changes to the recruit page.

Ensure newer job posts appear at the top and older ones at the bottom to stabilize visual regression tests.