### PR TITLE
test: vrt: Mask news article content in screenshot test

### DIFF
--- a/test/tests/visual-regression-test.spec.ts
+++ b/test/tests/visual-regression-test.spec.ts
@@ -101,7 +101,10 @@ test.describe('Visual Regression Tests', () => {
   test('individual news article comparison', async ({ page }) => {
     await page.goto('/news/2025-09-04/');
     await page.waitForLoadState('load');
-    await expect(page).toHaveScreenshot({ fullPage: true });
+    await expect(page).toHaveScreenshot({
+      fullPage: true,
+      mask: [page.locator('.news-article-content')],
+    });
   });
 });
 


### PR DESCRIPTION
News article content is rendered as text, which can vary and cause visual regression screenshots to fail unnecessarily. Mask the content area to keep the comparison stable.