### PR TITLE
sass: _typography: Enable auto-phrase for Japanese text wrapping

### DIFF
--- a/sass/_typography.scss
+++ b/sass/_typography.scss
@@ -9,6 +9,14 @@ h6 {
 	font-weight: normal;
 	line-height: normal;
 	font-family: 'Montserrat', 'Zen Kaku Gothic New', sans-serif;
+	&:lang(ja) {
+		text-wrap: initial;
+
+		@supports (word-break: auto-phrase) {
+			word-break: auto-phrase;
+			text-wrap: balance;
+		}
+	}
 }
 
 h1 {


### PR DESCRIPTION
Enable `word-break: auto-phrase` for `:lang(ja)` so `text-wrap: balance` works better with Japanese text.

Without `auto-phrase`, balanced wrapping can produce awkward line breaks in Japanese sentences.

Chrome 119 introduced `auto-phrase` support.

[1]: https://developer.chrome.com/blog/css-i18n-features
<img width="931" height="390" alt="Screenshot From 2026-04-09 19-36-49" src="https://github.com/user-attachments/assets/338da091-ac66-4319-af7b-6eb3c18b798a" />
<img width="931" height="390" alt="Screenshot From 2026-04-09 19-37-00" src="https://github.com/user-attachments/assets/8978d6da-9422-436f-8e1c-9eeddddf08a1" />
