### PR TITLE
content: news: Add OSC 2026 Hokkaido announcement

### DIFF
--- a/content/news/2026-04-09.en.md
+++ b/content/news/2026-04-09.en.md
@@ -1,0 +1,15 @@
++++
+title = "Space Cubics at Open Source Conference 2026 Hokkaido"
++++
+
+We will be participating in [Open Source Conference Hokkaido][1] again
+this year.
+
+See you in Sapporo on June 27, 2026!
+
+
+The day before, we are also planning to host [Zephyr Meetup: Sapporo, Japan][2].
+
+
+[1]: https://ospn.connpass.com/event/388639/
+[2]: https://zephyr-rtos.connpass.com/event/386410/

--- a/content/news/2026-04-09.md
+++ b/content/news/2026-04-09.md
@@ -1,0 +1,14 @@
++++
+title = "オープンソースカンファレンス 2026 Hokkaido に参加"
++++
+
+今年も [オープンソースカンファレンス Hokkaido][1] に参加します。
+
+2026年6月27日に、札幌でお会いしましょう!
+
+
+前日には [Zephyr Meetup: Sapporo, Japan][2] も開催予定です。
+
+
+[1]: https://ospn.connpass.com/event/388639/
+[2]: https://zephyr-rtos.connpass.com/event/386410/


### PR DESCRIPTION
Add a news entry announcing our participation in Open Source Conference 2026 Hokkaido in Sapporo on June 27, 2026.

Also mention the Zephyr Meetup in Sapporo planned for the previous day.