### PR TITLE
config: Capitalize navigation label text consistently

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -37,10 +37,10 @@ show_feed = true
 show_repo = true
 auto_hide = false
 links = [
-	{ url = "@/about-us.md", name = "About us" },
+	{ url = "@/about-us.md", name = "About Us" },
 	{ url = "@/products/_index.md", name = "Products" },
 	{ url = "@/news/_index.md", name = "News" },
-	{ url = "@/investor-relations/_index.md", name = "IR info" },
+	{ url = "@/investor-relations/_index.md", name = "IR Info" },
 	{ url = "@/recruit/_index.md", name = "Recruit" }
 ]
 

--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -52,7 +52,7 @@ prefooter_cards = ["recruit/_index.en.md", "investor-relations/_index.en.md", "c
 		img="empty_image.png",
 		alt="",
 		link="@/about-us.md",
-		link_text="About us",
+		link_text="About Us",
 		bottom_title=""
 	) %}
 	Space Cubics, Inc.

--- a/content/_index.md
+++ b/content/_index.md
@@ -49,7 +49,7 @@ prefooter_cards = ["recruit/_index.md", "investor-relations/_index.md", "contact
 		img="empty_image.png",
 		alt="",
 		link="@/about-us.md",
-		link_text="About us",
+		link_text="About Us",
 		bottom_title=""
 	) %}
 	私たち Space Cubics は


### PR DESCRIPTION
Capitalize Us and Info in the navigation and top page link labels.

This makes the English link text consistent across the site, including the global navigation and the homepage card link.