### PR TITLE
content: Change V1 memory spec to MRAM

### DIFF
--- a/content/products/scobc_v1.en.md
+++ b/content/products/scobc_v1.en.md
@@ -42,9 +42,9 @@ SC-OBC Module V1 is a cutting-edge OBC for space applications, powered by the AM
 ### Memory
 {% spec_sheet() %}
 	DDR4 | Rad-tolerant DDR4 memory w/ ECC 4 GByte
-	Boot Memory | NOR Flash 64 MByte (Redundancy)
+	Boot Memory | MRAM 64 MByte (Redundancy)
 	eMMC | 64 GByte
-	High Reliability Memory | FRAM 1 MByte × 2
+	High Reliability Memory | MRAM 8 MByte × 2
 {% end %}
 
 ### Pre-Installed Operating System

--- a/content/products/scobc_v1.md
+++ b/content/products/scobc_v1.md
@@ -42,9 +42,9 @@ CPU・FPGA・AI Engineを統合したヘテロジニアスプラットフォー�
 ### Memory
 {% spec_sheet() %}
 	DDR4 | Rad-tolerant DDR4 memory w/ ECC 4 GByte
-	Boot Memory | NOR Flash 64 MByte (Redundancy)
+	Boot Memory | MRAM 64 MByte (Redundancy)
 	eMMC | 64 GByte
-	High Reliability Memory | FRAM 1 MByte × 2
+	High Reliability Memory | MRAM 8 MByte × 2
 {% end %}
 
 ### Pre-Installed Operating System


### PR DESCRIPTION
In the latest version of the SC-OBC Module V1, MRAM is used for the Boot Memory and High Reliability Memory.

The product leaflet has already been changed.

  - https://forum.spacecubics.com/t/sc-obc-module-v1/123