### PR TITLE
content: products: v1: Remove the release date "Spring 2026"

### DIFF
--- a/content/products/scobc_v1.en.md
+++ b/content/products/scobc_v1.en.md
@@ -1,6 +1,6 @@
 +++
 title = "SC-OBC MODULE V1"
-description = "High-End Space Grade On-board Computer (Coming in Spring 2026) "
+description = "High-End Space Grade On-board Computer"
 template = "product.html"
 
 [extra]
@@ -78,8 +78,8 @@ SC-OBC Module V1 is a cutting-edge OBC for space applications, powered by the AM
 
 ## PRICE
 
-{% price(price_title="SC-OBC Module V1", price_number="", price_unit="", price_note="Coming in Spring 2026") %}
-SC-OBC Module V1 is scheduled for release in spring 2026. Please use our [contact form](/contact) to request more information.
+{% price(price_title="SC-OBC Module V1", price_number="", price_unit="", price_note="") %}
+Please use our [contact form](/contact) to request more information.
 {% end %}
 
 

--- a/content/products/scobc_v1.md
+++ b/content/products/scobc_v1.md
@@ -1,6 +1,6 @@
 +++
 title = "SC-OBC MODULE V1"
-description = "High-End Space Grade On-board Computer (2026年春発売予定) "
+description = "High-End Space Grade On-board Computer"
 template = "product.html"
 
 [extra]
@@ -78,8 +78,8 @@ CPU・FPGA・AI Engineを統合したヘテロジニアスプラットフォー�
 
 ## PRICE
 
-{% price(price_title="SC-OBC Module V1", price_number="", price_unit="", price_note="2026年春発売予定") %}
-SC-OBC Module V1は2026年春の発売を予定しています。詳しくは [お問い合わせフォーム](/contact) よりお問い合わせください。
+{% price(price_title="SC-OBC Module V1", price_number="", price_unit="", price_note="") %}
+詳しくは [お問い合わせフォーム](/contact) よりお問い合わせください。
 {% end %}
 
 


### PR DESCRIPTION
The SC-OBC Module V1 has already been released.
Now the release date "Spring 2026" is unnecessary.