### PR TITLE
github: workflows: vrt: Enable continue-on-error

### DIFF
--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -64,6 +64,7 @@ jobs:
         working-directory: test
         run: npx playwright test tests/visual-regression-test.spec.ts
         id: vrt-test
+        continue-on-error: true
 
       - name: Upload VRT results
         if: ${{ always() }}


### PR DESCRIPTION
VRT is treated as a failure when there are visual differences, but it does not affect whether the PR can be merged.

Enable continue-on-error so that the PR can still be merged even when differences are detected.