### PR TITLE
github: linkcheck: Prevent duplicate URL requests

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -30,7 +30,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: lychee
-          version: v0.23.0
+          version: v0.24.2
 
       - name: Install Zola ${{ env.ZOLA_VERSION }}
         run: |


### PR DESCRIPTION
Shared footer links are checked concurrently for every generated page, causing repeated requests to rate-limited services such as Instagram and intermittent HTTP 429 failures.

Update lychee to the release that serializes duplicate URL checks and reuses the first result.
