### PR TITLE
github: linkcheck: Exclude Instagram

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -47,4 +47,4 @@ jobs:
 
       - name: Run lychee
         run: |
-          lychee --verbose --root-dir "$PWD/public" public/**/*.html
+          lychee --config .lychee.toml --verbose --root-dir "$PWD/public" public/**/*.html

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,3 @@
+exclude = [
+    '^https?://(www\.)?instagram\.com/',
+]


### PR DESCRIPTION
Instagram redirects unauthenticated link checks repeatedly between the profile and login pages before returning HTTP 429. This makes the link check fail after several minutes even though the profile URL is valid.

Add a hidden lychee configuration file that excludes Instagram while continuing to check all other internal and external links. Point the workflow to the configuration explicitly because lychee does not discover the hidden filename automatically.
