### PR TITLE
github: workflows: Skip site checks for documentation

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,7 +1,11 @@
 name: Link Check
 
 on:
-  pull_request
+  pull_request:
+    paths-ignore:
+      - AGENTS.md
+      - doc/**
+      - README.md
 
 jobs:
   lychee:

--- a/.github/workflows/visual-regression-test.yml
+++ b/.github/workflows/visual-regression-test.yml
@@ -1,7 +1,11 @@
 name: Visual Regression Test
 
 on:
-  pull_request
+  pull_request:
+    paths-ignore:
+      - AGENTS.md
+      - doc/**
+      - README.md
 
 jobs:
   vrt:


### PR DESCRIPTION
Link checking and visual regression testing do not provide useful results when a pull request changes only repository documentation.

Exclude AGENTS.md, README.md, and the doc directory from both workflow triggers while retaining the checks for pull requests that also change site files.
