### PR TITLE
sass: general: Add consistent page gutters

### DIFF
--- a/sass/_general.scss
+++ b/sass/_general.scss
@@ -22,13 +22,10 @@ body {
 // Main content width constraint
 #main-content,
 .main-content {
+	width: calc(100% - 2rem);
 	max-width: 1100px;
 	margin: 0 auto;
 	position: relative;
-
-	@media only screen and (max-width: 479px) {
-		max-width: 100%;
-	}
 }
 
 // Hero section exception - allow full width background


### PR DESCRIPTION
Page content touches the viewport edges when the window is narrower than the site's maximum content width, making product pages difficult to scan.

Reserve a one-rem gutter on both sides through the shared main-content width constraint while preserving full-width sections. Cover both product pages across mobile, breakpoint, tablet, and desktop widths.

This fixes #303